### PR TITLE
Add remaining routes to the QMK and Lighting subsystems

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -13,7 +13,7 @@ use log::{info, LevelFilter};
 use tauri::State;
 use tokio::sync::Mutex;
 use xap::protocol::{
-    RGBConfig, RGBLightConfigGet, RGBLightConfigSave, RGBLightConfigSet, RGBLightEffectsQuery,
+    RGBLightConfig, RGBLightConfigGet, RGBLightConfigSave, RGBLightConfigSet, RGBLightEffectsQuery,
     XAPResult, XAPSecureStatus, XAPSecureStatusQuery, XAPVersion, XAPVersionQuery,
 };
 use xap::{XAPClient, XAPDevice, XAPError, XAPRequest};
@@ -85,7 +85,7 @@ async fn get_xap_version(state: State<'_, AppState>) -> XAPResult<XAPVersion> {
 }
 
 #[tauri::command]
-async fn get_rgblight_config(state: State<'_, AppState>) -> XAPResult<RGBConfig> {
+async fn get_rgblight_config(state: State<'_, AppState>) -> XAPResult<RGBLightConfig> {
     state.do_query(RGBLightConfigGet {}).await
 }
 
@@ -98,7 +98,7 @@ async fn get_rgblight_effects(state: State<'_, AppState>) -> XAPResult<Vec<u8>> 
 }
 
 #[tauri::command]
-async fn set_rgblight_config(arg: RGBConfig, state: State<'_, AppState>) -> XAPResult<()> {
+async fn set_rgblight_config(arg: RGBLightConfig, state: State<'_, AppState>) -> XAPResult<()> {
     state.do_query(RGBLightConfigSet { config: arg }).await
 }
 

--- a/src-tauri/src/xap/protocol/subsystems.rs
+++ b/src-tauri/src/xap/protocol/subsystems.rs
@@ -1,34 +1,9 @@
 // This file is just an "aggregator" for all queries/responses, which are divided into different files, one per subsystem
 
-mod common_imports;
 mod xap;
 mod qmk;
-mod rgblight;
+mod lighting;
 
-pub use xap::{
-    XAPVersion,
-    XAPVersionQuery,
-    XAPCapabilities,
-    XAPCapabilitiesQuery,
-    XAPEnabledSubsystems,
-    XAPEnabledSubsystemsQuery,
-    XAPSecureStatus,
-    XAPSecureStatusQuery,
-    XAPSecureStatusUnlock,
-    XAPSecureStatusLock,
-};
-pub use qmk::{
-    QMKVersion,
-    QMKVersionQuery,
-    QMKCapabilities,
-    QMKCapabilitiesQuery,
-};
-pub use rgblight::{
-    RGBConfig,
-    RGBLightCapabilitiesQuery,
-    RGBLightEffects,
-    RGBLightEffectsQuery,
-    RGBLightConfigGet,
-    RGBLightConfigSet,
-    RGBLightConfigSave,
-};
+pub use xap::*;
+pub use qmk::*;
+pub use lighting::*;

--- a/src-tauri/src/xap/protocol/subsystems.rs
+++ b/src-tauri/src/xap/protocol/subsystems.rs
@@ -2,6 +2,8 @@
 
 mod xap;
 mod qmk;
+mod keymap;
+mod remap;
 mod lighting;
 
 pub use xap::*;

--- a/src-tauri/src/xap/protocol/subsystems.rs
+++ b/src-tauri/src/xap/protocol/subsystems.rs
@@ -6,4 +6,6 @@ mod lighting;
 
 pub use xap::*;
 pub use qmk::*;
+pub use keymap::*;
+pub use remap::*;
 pub use lighting::*;

--- a/src-tauri/src/xap/protocol/subsystems/common_imports.rs
+++ b/src-tauri/src/xap/protocol/subsystems/common_imports.rs
@@ -1,6 +1,0 @@
-// This file contains imports which are common to all (or most) routes, to reduce code duplication at the start of each subsystem file
-
-pub use binrw::*;
-pub use crate::xap::XAPRequest;
-pub use serde::{Deserialize, Serialize};
-pub use ts_rs::TS;

--- a/src-tauri/src/xap/protocol/subsystems/keymap.rs
+++ b/src-tauri/src/xap/protocol/subsystems/keymap.rs
@@ -1,23 +1,5 @@
 use binrw::*;
 use crate::xap::XAPRequest;
-use serde::{Deserialize, Serialize};
-use ts_rs::TS;
-
-// ==============================
-// 0x4 0x1
-#[derive(BinRead, Debug)]
-pub struct KeymapCapabilities(u32);
-
-#[derive(BinWrite, Debug)]
-pub struct KeymapCapabilitiesQuery;
-
-impl XAPRequest for KeymapCapabilitiesQuery {
-    type Response = KeymapCapabilities;
-
-    fn id() -> &'static [u8] {
-        &[0x4, 0x1]
-    }
-}
 
 // ==============================
 // 0x4 0x1
@@ -54,13 +36,13 @@ impl XAPRequest for KeymapLayerCountQuery {
 // ==============================
 // 0x4 0x3
 #[derive(BinRead, Debug)]
-pub struct KeymapKeycode(u16);
+pub struct Keycode(u16);
 
 #[derive(BinWrite, Debug)]
 pub struct KeymapKeycodeQuery;
 
 impl XAPRequest for KeymapKeycodeQuery {
-    type Response = KeymapKeycode;
+    type Response = Keycode;
 
     fn id() -> &'static [u8] {
         &[0x4, 0x3]
@@ -69,14 +51,11 @@ impl XAPRequest for KeymapKeycodeQuery {
 
 // ==============================
 // 0x4 0x4
-#[derive(BinRead, Debug)]
-pub struct KeymapEncoder(u16);
-
 #[derive(BinWrite, Debug)]
 pub struct KeymapEncoderQuery;
 
 impl XAPRequest for KeymapEncoderQuery {
-    type Response = KeymapEncoder;
+    type Response = Keycode;
 
     fn id() -> &'static [u8] {
         &[0x4, 0x4]

--- a/src-tauri/src/xap/protocol/subsystems/keymap.rs
+++ b/src-tauri/src/xap/protocol/subsystems/keymap.rs
@@ -1,0 +1,84 @@
+use binrw::*;
+use crate::xap::XAPRequest;
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+
+// ==============================
+// 0x4 0x1
+#[derive(BinRead, Debug)]
+pub struct KeymapCapabilities(u32);
+
+#[derive(BinWrite, Debug)]
+pub struct KeymapCapabilitiesQuery;
+
+impl XAPRequest for KeymapCapabilitiesQuery {
+    type Response = KeymapCapabilities;
+
+    fn id() -> &'static [u8] {
+        &[0x4, 0x1]
+    }
+}
+
+// ==============================
+// 0x4 0x1
+#[derive(BinRead, Debug)]
+pub struct KeymapCapabilities(u32);
+
+#[derive(BinWrite, Debug)]
+pub struct KeymapCapabilitiesQuery;
+
+impl XAPRequest for KeymapCapabilitiesQuery {
+    type Response = KeymapCapabilities;
+
+    fn id() -> &'static [u8] {
+        &[0x4, 0x1]
+    }
+}
+
+// ==============================
+// 0x4 0x2
+#[derive(BinRead, Debug)]
+pub struct KeymapLayerCount(u8);
+
+#[derive(BinWrite, Debug)]
+pub struct KeymapLayerCountQuery;
+
+impl XAPRequest for KeymapLayerCountQuery {
+    type Response = KeymapLayerCount;
+
+    fn id() -> &'static [u8] {
+        &[0x4, 0x2]
+    }
+}
+
+// ==============================
+// 0x4 0x3
+#[derive(BinRead, Debug)]
+pub struct KeymapKeycode(u16);
+
+#[derive(BinWrite, Debug)]
+pub struct KeymapKeycodeQuery;
+
+impl XAPRequest for KeymapKeycodeQuery {
+    type Response = KeymapKeycode;
+
+    fn id() -> &'static [u8] {
+        &[0x4, 0x3]
+    }
+}
+
+// ==============================
+// 0x4 0x4
+#[derive(BinRead, Debug)]
+pub struct KeymapEncoder(u16);
+
+#[derive(BinWrite, Debug)]
+pub struct KeymapEncoderQuery;
+
+impl XAPRequest for KeymapEncoderQuery {
+    type Response = KeymapEncoder;
+
+    fn id() -> &'static [u8] {
+        &[0x4, 0x4]
+    }
+}

--- a/src-tauri/src/xap/protocol/subsystems/lighting.rs
+++ b/src-tauri/src/xap/protocol/subsystems/lighting.rs
@@ -1,4 +1,5 @@
 // Aggregator of the different lighting modes controlled by XAP, each one on its own file + Capabilities query
+
 use binrw::*;
 use crate::xap::XAPRequest;
 

--- a/src-tauri/src/xap/protocol/subsystems/lighting.rs
+++ b/src-tauri/src/xap/protocol/subsystems/lighting.rs
@@ -1,0 +1,25 @@
+// Aggregator of the different lighting modes controlled by XAP, each one on its own file + Capabilities query
+use binrw::*;
+use crate::xap::XAPRequest;
+
+mod backlight;
+mod rgblight;
+mod rgbmatrix;
+
+pub use backlight::*;
+pub use rgblight::*;
+pub use rgbmatrix::*;
+
+#[derive(BinRead, Debug)]
+pub struct LightingCapabilities(u32);
+
+#[derive(BinWrite, Debug)]
+pub struct LightingCapabilitiesQuery;
+
+impl XAPRequest for LightingCapabilitiesQuery {
+    type Response = LightingCapabilities;
+
+    fn id() -> &'static [u8] {
+        &[0x6, 0x1]
+    }
+}

--- a/src-tauri/src/xap/protocol/subsystems/lighting/backlight.rs
+++ b/src-tauri/src/xap/protocol/subsystems/lighting/backlight.rs
@@ -1,0 +1,101 @@
+use binrw::*;
+use crate::xap::XAPRequest;
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+
+// ==============================
+// 0x6 0x2 0x1
+#[derive(BinRead, Debug)]
+pub struct BacklightCapabilities(u32);
+
+#[derive(BinWrite, Debug)]
+pub struct BacklightCapabilitiesQuery;
+
+impl XAPRequest for BacklightCapabilitiesQuery {
+    type Response = BacklightCapabilities;
+
+    fn id() -> &'static [u8] {
+        &[0x6, 0x2, 0x1]
+    }
+}
+
+// ==============================
+// 0x6 0x2 0x2
+#[derive(BinRead, Debug)]
+pub struct BacklightEffects(u8);
+
+impl BacklightEffects {
+    pub fn enabled_effect_list(&self) -> Vec<u8> {
+        let mut effects = Vec::with_capacity(64);
+
+        let bits = self.0;
+
+        for i in 0..64 {
+            if ((bits >> i) & 1) == 1 {
+                effects.push(i)
+            }
+        }
+
+        effects
+    }
+}
+
+#[derive(BinWrite, Debug)]
+pub struct BacklightEffectsQuery;
+
+impl XAPRequest for BacklightEffectsQuery {
+    type Response = BacklightEffects;
+
+    fn id() -> &'static [u8] {
+        &[0x6, 0x2, 0x2]
+    }
+}
+
+// ==============================
+// 0x6 0x2 0x3
+#[derive(BinWrite, BinRead, Debug, TS, Serialize, Deserialize)]
+#[ts(export)]
+pub struct BacklightConfig {
+    pub enable: u8,
+    pub mode: u8,
+    pub val: u8,
+}
+
+#[derive(BinWrite, Debug)]
+pub struct BacklightConfigGet;
+
+impl XAPRequest for BacklightConfigGet {
+    type Response = BacklightConfig;
+
+    fn id() -> &'static [u8] {
+        &[0x6, 0x2, 0x3]
+    }
+}
+
+// ==============================
+// 0x6 0x2 0x4
+#[derive(BinWrite, Debug)]
+pub struct BacklightConfigSet {
+    pub config: BacklightConfig,
+}
+
+impl XAPRequest for BacklightConfigSet {
+    type Response = ();
+
+    fn id() -> &'static [u8] {
+        &[0x6, 0x2, 0x4]
+    }
+}
+
+// ==============================
+// 0x6 0x2 0x5
+#[derive(BinWrite, Debug)]
+pub struct BacklightConfigSave;
+
+impl XAPRequest for BacklightConfigSave {
+    type Response = ();
+
+    fn id() -> &'static [u8] {
+        &[0x6, 0x2, 0x5]
+    }
+}

--- a/src-tauri/src/xap/protocol/subsystems/lighting/rgblight.rs
+++ b/src-tauri/src/xap/protocol/subsystems/lighting/rgblight.rs
@@ -1,18 +1,10 @@
-// RGBLIGHT SUBSYSTEM - INCOMPLETE!
+use binrw::*;
+use crate::xap::XAPRequest;
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
 
-use super::common_imports::*;
-
-#[derive(BinWrite, BinRead, Debug, TS, Serialize, Deserialize)]
-#[ts(export)]
-pub struct RGBConfig {
-    pub enable: u8,
-    pub mode: u8,
-    pub hue: u8,
-    pub sat: u8,
-    pub val: u8,
-    pub speed: u8,
-}
-
+// ==============================
+// 0x6 0x3 0x1
 #[derive(BinRead, Debug)]
 pub struct RGBLightCapabilities(u32);
 
@@ -20,13 +12,15 @@ pub struct RGBLightCapabilities(u32);
 pub struct RGBLightCapabilitiesQuery;
 
 impl XAPRequest for RGBLightCapabilitiesQuery {
-    type Response = RGBConfig;
+    type Response = RGBLightCapabilities;
 
     fn id() -> &'static [u8] {
         &[0x6, 0x3, 0x1]
     }
 }
 
+// ==============================
+// 0x6 0x3 0x2
 #[derive(BinRead, Debug)]
 pub struct RGBLightEffects(u64);
 
@@ -57,20 +51,35 @@ impl XAPRequest for RGBLightEffectsQuery {
     }
 }
 
+// ==============================
+// 0x6 0x3 0x3
+#[derive(BinWrite, BinRead, Debug, TS, Serialize, Deserialize)]
+#[ts(export)]
+pub struct RGBLightConfig {
+    pub enable: u8,
+    pub mode: u8,
+    pub hue: u8,
+    pub sat: u8,
+    pub val: u8,
+    pub speed: u8,
+}
+
 #[derive(BinWrite, Debug)]
 pub struct RGBLightConfigGet;
 
 impl XAPRequest for RGBLightConfigGet {
-    type Response = RGBConfig;
+    type Response = RGBLightConfig;
 
     fn id() -> &'static [u8] {
         &[0x6, 0x3, 0x3]
     }
 }
 
+// ==============================
+// 0x6 0x3 0x4
 #[derive(BinWrite, Debug)]
 pub struct RGBLightConfigSet {
-    pub config: RGBConfig,
+    pub config: RGBLightConfig,
 }
 
 impl XAPRequest for RGBLightConfigSet {
@@ -81,6 +90,8 @@ impl XAPRequest for RGBLightConfigSet {
     }
 }
 
+// ==============================
+// 0x6 0x3 0x5
 #[derive(BinWrite, Debug)]
 pub struct RGBLightConfigSave;
 

--- a/src-tauri/src/xap/protocol/subsystems/lighting/rgbmatrix.rs
+++ b/src-tauri/src/xap/protocol/subsystems/lighting/rgbmatrix.rs
@@ -1,0 +1,105 @@
+use binrw::*;
+use crate::xap::XAPRequest;
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+
+// ==============================
+// 0x6 0x4 0x1
+#[derive(BinRead, Debug)]
+pub struct RGBMatrixCapabilities(u32);
+
+#[derive(BinWrite, Debug)]
+pub struct RGBMatrixCapabilitiesQuery;
+
+impl XAPRequest for RGBMatrixCapabilitiesQuery {
+    type Response = RGBMatrixCapabilities;
+
+    fn id() -> &'static [u8] {
+        &[0x6, 0x4, 0x1]
+    }
+}
+
+// ==============================
+// 0x6 0x4 0x2
+#[derive(BinRead, Debug)]
+pub struct RGBMatrixEffects(u64);
+
+impl RGBMatrixEffects {
+    pub fn enabled_effect_list(&self) -> Vec<u8> {
+        let mut effects = Vec::with_capacity(64);
+
+        let bits = self.0;
+
+        for i in 0..64 {
+            if ((bits >> i) & 1) == 1 {
+                effects.push(i)
+            }
+        }
+
+        effects
+    }
+}
+
+#[derive(BinWrite, Debug)]
+pub struct RGBMatrixEffectsQuery;
+
+impl XAPRequest for RGBMatrixEffectsQuery {
+    type Response = RGBMatrixEffects;
+
+    fn id() -> &'static [u8] {
+        &[0x6, 0x4, 0x2]
+    }
+}
+
+// ==============================
+// 0x6 0x4 0x3
+#[derive(BinWrite, BinRead, Debug, TS, Serialize, Deserialize)]
+#[ts(export)]
+pub struct RGBMatrixConfig {
+    pub enable: u8,
+    pub mode: u8,
+    pub hue: u8,
+    pub sat: u8,
+    pub val: u8,
+    pub speed: u8,
+    pub flags: u8,
+}
+
+#[derive(BinWrite, Debug)]
+pub struct RGBMatrixConfigGet;
+
+impl XAPRequest for RGBMatrixConfigGet {
+    type Response = RGBMatrixConfig;
+
+    fn id() -> &'static [u8] {
+        &[0x6, 0x4, 0x3]
+    }
+}
+
+// ==============================
+// 0x6 0x4 0x4
+#[derive(BinWrite, Debug)]
+pub struct RGBMatrixConfigSet {
+    pub config: RGBMatrixConfig,
+}
+
+impl XAPRequest for RGBMatrixConfigSet {
+    type Response = ();
+
+    fn id() -> &'static [u8] {
+        &[0x6, 0x4, 0x4]
+    }
+}
+
+// ==============================
+// 0x6 0x4 0x5
+#[derive(BinWrite, Debug)]
+pub struct RGBMatrixConfigSave;
+
+impl XAPRequest for RGBMatrixConfigSave {
+    type Response = ();
+
+    fn id() -> &'static [u8] {
+        &[0x6, 0x4, 0x5]
+    }
+}

--- a/src-tauri/src/xap/protocol/subsystems/qmk.rs
+++ b/src-tauri/src/xap/protocol/subsystems/qmk.rs
@@ -144,6 +144,10 @@ impl XAPRequest for QMKJumpToBootloaderQuery {
     fn id() -> &'static [u8] {
         &[0x1, 0x7]
     }
+
+    fn is_secure() -> bool {
+        true
+    }
 }
 
 // ==============================
@@ -175,5 +179,9 @@ impl XAPRequest for QMKReinitializeEepromQuery {
 
     fn id() -> &'static [u8] {
         &[0x1, 0x9]
+    }
+
+    fn is_secure() -> bool {
+        true
     }
 }

--- a/src-tauri/src/xap/protocol/subsystems/qmk.rs
+++ b/src-tauri/src/xap/protocol/subsystems/qmk.rs
@@ -1,5 +1,7 @@
 use binrw::*;
 use crate::xap::XAPRequest;
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
 
 // ==============================
 // 0x1 0x0
@@ -109,8 +111,16 @@ impl XAPRequest for QMKConfigBlobLengthQuery {
 #[derive(BinRead, Debug)]
 pub struct ConfigBlobChunk([u8; 32]);
 
+#[derive(BinWrite, BinRead, Debug, TS, Serialize, Deserialize)]
+#[ts(export)]
+pub struct ConfigBlobOffset {
+    pub offset: u16,
+}
+
 #[derive(BinWrite, Debug)]
-pub struct ConfigBlobChunkQuery;
+pub struct ConfigBlobChunkQuery {
+    offset: ConfigBlobOffset,
+}
 
 impl XAPRequest for ConfigBlobChunkQuery {
     type Response = ConfigBlobChunk;

--- a/src-tauri/src/xap/protocol/subsystems/qmk.rs
+++ b/src-tauri/src/xap/protocol/subsystems/qmk.rs
@@ -1,7 +1,8 @@
-// QMK SUBSYSTEM - INCOMPLETE!
+use binrw::*;
+use crate::xap::XAPRequest;
 
-use super::common_imports::*;
-
+// ==============================
+// 0x1 0x0
 #[derive(BinRead, Debug)]
 pub struct QMKVersion(u32);
 
@@ -16,6 +17,8 @@ impl XAPRequest for QMKVersionQuery {
     }
 }
 
+// ==============================
+// 0x1 0x1
 #[derive(BinRead, Debug)]
 pub struct QMKCapabilities(u32);
 
@@ -27,5 +30,140 @@ impl XAPRequest for QMKCapabilitiesQuery {
 
     fn id() -> &'static [u8] {
         &[0x1, 0x1]
+    }
+}
+
+// ==============================
+// 0x1 0x2
+#[derive(BinRead, Debug)]
+pub struct QMKBoardIdentifiers {
+    pub vendor_id: u16,
+    pub product_id: u16,
+    pub product_version: u16,
+    pub qmk_identifier: u32,
+}
+
+#[derive(BinWrite, Debug)]
+pub struct QMKBoardIdentifiersQuery;
+
+impl XAPRequest for QMKBoardIdentifiersQuery {
+    type Response = QMKBoardIdentifiers;
+
+    fn id() -> &'static [u8] {
+        &[0x1, 0x2]
+    }
+}
+
+// ==============================
+// 0x1 0x3
+// TODO: Implement BinRead for String
+#[derive(BinRead, Debug)]
+pub struct QMKBoardManufacturer(String);
+
+#[derive(BinWrite, Debug)]
+pub struct QMKBoardManufacturerQuery;
+
+impl XAPRequest for QMKBoardManufacturerQuery {
+    type Response = QMKBoardManufacturer;
+
+    fn id() -> &'static [u8] {
+        &[0x1, 0x3]
+    }
+}
+
+// ==============================
+// 0x1 0x4
+// TODO: Implement BinRead for String
+#[derive(BinRead, Debug)]
+pub struct QMKProductName(String);
+
+#[derive(BinWrite, Debug)]
+pub struct QMKProductNameQuery;
+
+impl XAPRequest for QMKProductNameQuery {
+    type Response = QMKProductName;
+
+    fn id() -> &'static [u8] {
+        &[0x1, 0x4]
+    }
+}
+
+// ==============================
+// 0x1 0x5
+#[derive(BinRead, Debug)]
+pub struct QMKConfigBlobLength(u16);
+
+#[derive(BinWrite, Debug)]
+pub struct QMKConfigBlobLengthQuery;
+
+impl XAPRequest for QMKConfigBlobLengthQuery {
+    type Response = QMKConfigBlobLength;
+
+    fn id() -> &'static [u8] {
+        &[0x1, 0x5]
+    }
+}
+
+// ==============================
+// 0x1 0x6
+#[derive(BinRead, Debug)]
+pub struct ConfigBlobChunk([u8; 32]);
+
+#[derive(BinWrite, Debug)]
+pub struct ConfigBlobChunkQuery;
+
+impl XAPRequest for ConfigBlobChunkQuery {
+    type Response = ConfigBlobChunk;
+
+    fn id() -> &'static [u8] {
+        &[0x1, 0x6]
+    }
+}
+
+// ==============================
+// 0x1 0x7
+#[derive(BinRead, Debug)]
+pub struct QMKJumpToBootloader(u8);
+
+#[derive(BinWrite, Debug)]
+pub struct QMKJumpToBootloaderQuery;
+
+impl XAPRequest for QMKJumpToBootloaderQuery {
+    type Response = QMKJumpToBootloader;
+
+    fn id() -> &'static [u8] {
+        &[0x1, 0x7]
+    }
+}
+
+// ==============================
+// 0x1 0x8
+#[derive(BinRead, Debug)]
+pub struct QMKHardwareIdentifier([u32;4]);
+
+#[derive(BinWrite, Debug)]
+pub struct QMKHardwareIdentifierQuery;
+
+impl XAPRequest for QMKHardwareIdentifierQuery {
+    type Response = QMKHardwareIdentifier;
+
+    fn id() -> &'static [u8] {
+        &[0x1, 0x8]
+    }
+}
+
+// ==============================
+// 0x1 0x9
+#[derive(BinRead, Debug)]
+pub struct QMKReinitializeEeprom(u8);
+
+#[derive(BinWrite, Debug)]
+pub struct QMKReinitializeEepromQuery;
+
+impl XAPRequest for QMKReinitializeEepromQuery {
+    type Response = QMKReinitializeEeprom;
+
+    fn id() -> &'static [u8] {
+        &[0x1, 0x9]
     }
 }

--- a/src-tauri/src/xap/protocol/subsystems/remap.rs
+++ b/src-tauri/src/xap/protocol/subsystems/remap.rs
@@ -20,22 +20,6 @@ impl XAPRequest for RemapCapabilitiesQuery {
 }
 
 // ==============================
-// 0x5 0x1
-#[derive(BinRead, Debug)]
-pub struct RemapCapabilities(u32);
-
-#[derive(BinWrite, Debug)]
-pub struct RemapCapabilitiesQuery;
-
-impl XAPRequest for RemapCapabilitiesQuery {
-    type Response = RemapCapabilities;
-
-    fn id() -> &'static [u8] {
-        &[0x5, 0x1]
-    }
-}
-
-// ==============================
 // 0x5 0x2
 #[derive(BinRead, Debug)]
 pub struct RemapLayerCount(u8);
@@ -53,14 +37,22 @@ impl XAPRequest for RemapLayerCountQuery {
 
 // ==============================
 // 0x5 0x3
-#[derive(BinRead, Debug)]
-pub struct RemapKeycode(u16);
+#[derive(BinWrite, BinRead, Debug, TS, Serialize, Deserialize)]
+#[ts(export)]
+pub struct RemapKeycodeConfig {
+    pub layer: u8,
+    pub row: u8,
+    pub column: u8,
+    pub keycode: u16,
+}
 
 #[derive(BinWrite, Debug)]
-pub struct RemapKeycodeQuery;
+pub struct RemapKeycodeQuery {
+    pub config: RemapKeycodeConfig,
+}
 
 impl XAPRequest for RemapKeycodeQuery {
-    type Response = RemapKeycode;
+    type Response = ();
 
     fn id() -> &'static [u8] {
         &[0x5, 0x3]
@@ -69,14 +61,22 @@ impl XAPRequest for RemapKeycodeQuery {
 
 // ==============================
 // 0x5 0x4
-#[derive(BinRead, Debug)]
-pub struct RemapEncoder(u16);
+#[derive(BinWrite, BinRead, Debug, TS, Serialize, Deserialize)]
+#[ts(export)]
+pub struct RemapEncoderConfig {
+    pub layer: u8,
+    pub encoder: u8,
+    pub clockwise: u8,
+    pub keycode: u16,
+}
 
 #[derive(BinWrite, Debug)]
-pub struct RemapEncoderQuery;
+pub struct RemapEncoderQuery {
+    config: RemapEncoderConfig,
+}
 
 impl XAPRequest for RemapEncoderQuery {
-    type Response = RemapEncoder;
+    type Response = ();
 
     fn id() -> &'static [u8] {
         &[0x5, 0x4]

--- a/src-tauri/src/xap/protocol/subsystems/remap.rs
+++ b/src-tauri/src/xap/protocol/subsystems/remap.rs
@@ -57,6 +57,10 @@ impl XAPRequest for RemapKeycodeQuery {
     fn id() -> &'static [u8] {
         &[0x5, 0x3]
     }
+
+    fn is_secure() -> bool {
+        true
+    }
 }
 
 // ==============================
@@ -80,5 +84,9 @@ impl XAPRequest for RemapEncoderQuery {
 
     fn id() -> &'static [u8] {
         &[0x5, 0x4]
+    }
+
+    fn is_secure() -> bool {
+        true
     }
 }

--- a/src-tauri/src/xap/protocol/subsystems/remap.rs
+++ b/src-tauri/src/xap/protocol/subsystems/remap.rs
@@ -1,0 +1,84 @@
+use binrw::*;
+use crate::xap::XAPRequest;
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+
+// ==============================
+// 0x5 0x1
+#[derive(BinRead, Debug)]
+pub struct RemapCapabilities(u32);
+
+#[derive(BinWrite, Debug)]
+pub struct RemapCapabilitiesQuery;
+
+impl XAPRequest for RemapCapabilitiesQuery {
+    type Response = RemapCapabilities;
+
+    fn id() -> &'static [u8] {
+        &[0x5, 0x1]
+    }
+}
+
+// ==============================
+// 0x5 0x1
+#[derive(BinRead, Debug)]
+pub struct RemapCapabilities(u32);
+
+#[derive(BinWrite, Debug)]
+pub struct RemapCapabilitiesQuery;
+
+impl XAPRequest for RemapCapabilitiesQuery {
+    type Response = RemapCapabilities;
+
+    fn id() -> &'static [u8] {
+        &[0x5, 0x1]
+    }
+}
+
+// ==============================
+// 0x5 0x2
+#[derive(BinRead, Debug)]
+pub struct RemapLayerCount(u8);
+
+#[derive(BinWrite, Debug)]
+pub struct RemapLayerCountQuery;
+
+impl XAPRequest for RemapLayerCountQuery {
+    type Response = RemapLayerCount;
+
+    fn id() -> &'static [u8] {
+        &[0x5, 0x2]
+    }
+}
+
+// ==============================
+// 0x5 0x3
+#[derive(BinRead, Debug)]
+pub struct RemapKeycode(u16);
+
+#[derive(BinWrite, Debug)]
+pub struct RemapKeycodeQuery;
+
+impl XAPRequest for RemapKeycodeQuery {
+    type Response = RemapKeycode;
+
+    fn id() -> &'static [u8] {
+        &[0x5, 0x3]
+    }
+}
+
+// ==============================
+// 0x5 0x4
+#[derive(BinRead, Debug)]
+pub struct RemapEncoder(u16);
+
+#[derive(BinWrite, Debug)]
+pub struct RemapEncoderQuery;
+
+impl XAPRequest for RemapEncoderQuery {
+    type Response = RemapEncoder;
+
+    fn id() -> &'static [u8] {
+        &[0x5, 0x4]
+    }
+}

--- a/src-tauri/src/xap/protocol/subsystems/xap.rs
+++ b/src-tauri/src/xap/protocol/subsystems/xap.rs
@@ -1,7 +1,9 @@
-// XAP SUBSYSTEM
+use binrw::*;
+use crate::xap::XAPRequest;
+use serde::Serialize;
 
-use super::common_imports::*;
-
+// ==============================
+// 0x0 0x0
 #[binread]
 #[derive(Debug, Serialize)]
 pub struct XAPVersion(u32);
@@ -17,6 +19,8 @@ impl XAPRequest for XAPVersionQuery {
     }
 }
 
+// ==============================
+// 0x0 0x1
 #[derive(BinRead, Debug)]
 pub struct XAPCapabilities(u32);
 
@@ -31,6 +35,8 @@ impl XAPRequest for XAPCapabilitiesQuery {
     }
 }
 
+// ==============================
+// 0x0 0x2
 #[derive(BinRead, Debug)]
 pub struct XAPEnabledSubsystems(u32);
 
@@ -45,17 +51,8 @@ impl XAPRequest for XAPEnabledSubsystemsQuery {
     }
 }
 
-#[derive(BinWrite, Debug)]
-pub struct XAPSecureStatusQuery;
-
-impl XAPRequest for XAPSecureStatusQuery {
-    type Response = XAPSecureStatus;
-
-    fn id() -> &'static [u8] {
-        &[0x0, 0x3]
-    }
-}
-
+// ==============================
+// 0x0 0x3
 #[derive(Debug, Serialize)]
 pub enum XAPSecureStatus {
     Disabled,
@@ -81,6 +78,19 @@ impl BinRead for XAPSecureStatus {
 }
 
 #[derive(BinWrite, Debug)]
+pub struct XAPSecureStatusQuery;
+
+impl XAPRequest for XAPSecureStatusQuery {
+    type Response = XAPSecureStatus;
+
+    fn id() -> &'static [u8] {
+        &[0x0, 0x3]
+    }
+}
+
+// ==============================
+// 0x0 0x4
+#[derive(BinWrite, Debug)]
 pub struct XAPSecureStatusUnlock;
 
 impl XAPRequest for XAPSecureStatusUnlock {
@@ -91,6 +101,8 @@ impl XAPRequest for XAPSecureStatusUnlock {
     }
 }
 
+// ==============================
+// 0x0 0x5
 #[derive(BinWrite, Debug)]
 pub struct XAPSecureStatusLock;
 


### PR DESCRIPTION
As the title says, added the routes that were missing on the already implemented modules.
Minor changes:
- Changed the file structure a little
- Renamed a couple of things to avoid confusions

To-do next:
- `BinRead` for `String` yet to be added, dunno how could I pass XAP's payload length to the structs in order to format them propperly. Can likely just trim the tail of the string later on, but would be gross.
- I'd like to define the loop that gets all different config blobs (and other similar abstractions) in a file, rather than having them in `main.rs`, where/how would to put and name it?   