### PR TITLE
[Bugfix] Correct logging of messages being sent

### DIFF
--- a/src-tauri/src/xap/hid/device.rs
+++ b/src-tauri/src/xap/hid/device.rs
@@ -178,11 +178,11 @@ impl XAPDevice {
         let mut report = [0; XAP_REPORT_SIZE + 1];
 
         // Add trailing zero byte for the report Id to HID report
-        trace!("send XAP report with payload {:?}", &report[1..]);
         let mut writer = Cursor::new(&mut report[1..]);
         writer
             .write_le(&request)
             .map_err(|err| ClientError::from(XAPError::BitHandling(err)))?;
+        trace!("send XAP report with payload {:?}", &report[1..]);
 
         self.tx_device.write(&report)?;
 


### PR DESCRIPTION
## Description

As per title, code currently logs **before** writing the data into the buffer that will be sent. Thus showing a whole bunch of 0s