### PR TITLE
Adjust keymap view

### DIFF
--- a/src/pages/KeymapView.vue
+++ b/src/pages/KeymapView.vue
@@ -50,8 +50,9 @@
         return {
             top: `${layout.y * 5}rem`,
             left: `${layout.x * 5}rem`,
-            width: `${layout.w! * 4.5}rem`,
-            height: `${layout.h! * 4.5}rem`,
+            width: `${layout.w! * 5 - 0.5}rem`,
+            height: `${layout.h! * 5 - 0.5}rem`,
+            margin: `0.25rem`,
         }
     }
 

--- a/src/pages/KeymapView.vue
+++ b/src/pages/KeymapView.vue
@@ -139,7 +139,7 @@
             <!--   Keymap   -->
             <q-tab-panels v-model="layerTab">
                 <q-tab-panel
-                    :style="{ height: `${Math.max(keymap?.size.y ?? 2, 2) * 3}rem` }"
+                    :style="{ height: `${Math.max(keymap?.size.y ?? 2, 2) * 6}rem` }"
                     v-for="(layer, layer_idx) in keymap?.keys"
                     :name="layer_idx"
                 >


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

This PR add two adjustment to the keymap view.

1. The height of keymap panel is calculated with a unit of 3rem, which is too small to display the entire keymap when unit size for keys is 5rem. This PR increase it to 6rem.

BEFORE
![Screenshot 2024-10-24 at 12 06 16 AM](https://github.com/user-attachments/assets/67c00a8f-b907-4546-a87d-51c380b1bdcc)
AFTER
![Screenshot 2024-10-24 at 12 05 44 AM](https://github.com/user-attachments/assets/e7d722bf-5494-4f9e-bc95-61788f710d5e)

2. The gap between 1u and larger keys are nonuniform. This PR changes the key size calculation based on unit size (layout.w * 5rem) minus the fixed gap (0.5rem). I also added a 0.25 margin around the key to make the key aligned in the center. 

BEFORE
![Screenshot 2024-10-24 at 12 04 05 AM](https://github.com/user-attachments/assets/f67833ed-9cf6-4cb0-a72a-68863d3274a8)
AFTER
![Screenshot 2024-10-24 at 12 03 36 AM](https://github.com/user-attachments/assets/7007f1f7-a420-4b24-b4ff-70a32034a0eb)


<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
