### PR TITLE
Improve basic keycode display with ANSI keyboard layout

### DIFF
--- a/src-tauri/gen/schemas/macOS-schema.json
+++ b/src-tauri/gen/schemas/macOS-schema.json
@@ -1,0 +1,6431 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CapabilityFile",
+  "description": "Capability formats accepted in a capability file.",
+  "anyOf": [
+    {
+      "description": "A single capability.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Capability"
+        }
+      ]
+    },
+    {
+      "description": "A list of capabilities.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Capability"
+      }
+    },
+    {
+      "description": "A list of capabilities.",
+      "type": "object",
+      "required": [
+        "capabilities"
+      ],
+      "properties": {
+        "capabilities": {
+          "description": "The list of capabilities.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Capability"
+          }
+        }
+      }
+    }
+  ],
+  "definitions": {
+    "Capability": {
+      "description": "a grouping and boundary mechanism developers can use to separate windows or plugins functionality from each other at runtime.\n\nIf a window is not matching any capability then it has no access to the IPC layer at all.\n\nThis can be done to create trust groups and reduce impact of vulnerabilities in certain plugins or windows. Windows can be added to a capability by exact name or glob patterns like *, admin-* or main-window.",
+      "type": "object",
+      "required": [
+        "identifier",
+        "permissions"
+      ],
+      "properties": {
+        "identifier": {
+          "description": "Identifier of the capability.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Description of the capability.",
+          "default": "",
+          "type": "string"
+        },
+        "remote": {
+          "description": "Configure remote URLs that can use the capability permissions.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CapabilityRemote"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "local": {
+          "description": "Whether this capability is enabled for local app URLs or not. Defaults to `true`.",
+          "default": true,
+          "type": "boolean"
+        },
+        "windows": {
+          "description": "List of windows that uses this capability. Can be a glob pattern.\n\nOn multiwebview windows, prefer [`Self::webviews`] for a fine grained access control.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "webviews": {
+          "description": "List of webviews that uses this capability. Can be a glob pattern.\n\nThis is only required when using on multiwebview contexts, by default all child webviews of a window that matches [`Self::windows`] are linked.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "permissions": {
+          "description": "List of permissions attached to this capability. Must include the plugin name as prefix in the form of `${plugin-name}:${permission-name}`.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/PermissionEntry"
+          }
+        },
+        "platforms": {
+          "description": "Target platforms this capability applies. By default all platforms are affected by this capability.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        }
+      }
+    },
+    "CapabilityRemote": {
+      "description": "Configuration for remote URLs that are associated with the capability.",
+      "type": "object",
+      "required": [
+        "urls"
+      ],
+      "properties": {
+        "urls": {
+          "description": "Remote domains this capability refers to using the [URLPattern standard](https://urlpattern.spec.whatwg.org/).\n\n# Examples\n\n- \"https://*.mydomain.dev\": allows subdomains of mydomain.dev - \"https://mydomain.dev/api/*\": allows any subpath of mydomain.dev/api",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PermissionEntry": {
+      "description": "An entry for a permission value in a [`Capability`] can be either a raw permission [`Identifier`] or an object that references a permission and extends its scope.",
+      "anyOf": [
+        {
+          "description": "Reference a permission or permission set by identifier.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Identifier"
+            }
+          ]
+        },
+        {
+          "description": "Reference a permission or permission set by identifier and extends its scope.",
+          "type": "object",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "identifier"
+              ],
+              "properties": {
+                "identifier": {
+                  "oneOf": [
+                    {
+                      "description": "fs:default -> # Tauri `fs` default permissions\n\nThis configuration file defines the default permissions granted\nto the filesystem.\n\n### Granted Permissions\n\nThis default permission set enables all read-related commands and\nallows access to the `$APP` folder and sub directories created in it.\nThe location of the `$APP` folder depends on the operating system,\nwhere the application is run.\n\nIn general the `$APP` folder needs to be manually created\nby the application at runtime, before accessing files or folders\nin it is possible.\n\n### Denied Permissions\n\nThis default permission set prevents access to critical components\nof the Tauri application by default.\nOn Windows the webview data folder access is denied.\n\n",
+                      "type": "string",
+                      "enum": [
+                        "fs:default"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-app-meta -> This allows non-recursive read access to metadata of the `$APP` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-app-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-app-meta-recursive -> This allows full recursive read access to metadata of the `$APP` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-app-meta-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-app-read -> This allows non-recursive read access to the `$APP` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-app-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-app-read-recursive -> This allows full recursive read access to the complete `$APP` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-app-read-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-app-write -> This allows non-recursive write access to the `$APP` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-app-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-app-write-recursive -> This allows full recursive write access to the complete `$APP` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-app-write-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-appcache-meta -> This allows non-recursive read access to metadata of the `$APPCACHE` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-appcache-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-appcache-meta-recursive -> This allows full recursive read access to metadata of the `$APPCACHE` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-appcache-meta-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-appcache-read -> This allows non-recursive read access to the `$APPCACHE` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-appcache-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-appcache-read-recursive -> This allows full recursive read access to the complete `$APPCACHE` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-appcache-read-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-appcache-write -> This allows non-recursive write access to the `$APPCACHE` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-appcache-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-appcache-write-recursive -> This allows full recursive write access to the complete `$APPCACHE` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-appcache-write-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-appconfig-meta -> This allows non-recursive read access to metadata of the `$APPCONFIG` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-appconfig-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-appconfig-meta-recursive -> This allows full recursive read access to metadata of the `$APPCONFIG` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-appconfig-meta-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-appconfig-read -> This allows non-recursive read access to the `$APPCONFIG` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-appconfig-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-appconfig-read-recursive -> This allows full recursive read access to the complete `$APPCONFIG` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-appconfig-read-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-appconfig-write -> This allows non-recursive write access to the `$APPCONFIG` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-appconfig-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-appconfig-write-recursive -> This allows full recursive write access to the complete `$APPCONFIG` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-appconfig-write-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-appdata-meta -> This allows non-recursive read access to metadata of the `$APPDATA` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-appdata-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-appdata-meta-recursive -> This allows full recursive read access to metadata of the `$APPDATA` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-appdata-meta-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-appdata-read -> This allows non-recursive read access to the `$APPDATA` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-appdata-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-appdata-read-recursive -> This allows full recursive read access to the complete `$APPDATA` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-appdata-read-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-appdata-write -> This allows non-recursive write access to the `$APPDATA` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-appdata-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-appdata-write-recursive -> This allows full recursive write access to the complete `$APPDATA` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-appdata-write-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-applocaldata-meta -> This allows non-recursive read access to metadata of the `$APPLOCALDATA` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-applocaldata-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-applocaldata-meta-recursive -> This allows full recursive read access to metadata of the `$APPLOCALDATA` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-applocaldata-meta-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-applocaldata-read -> This allows non-recursive read access to the `$APPLOCALDATA` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-applocaldata-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-applocaldata-read-recursive -> This allows full recursive read access to the complete `$APPLOCALDATA` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-applocaldata-read-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-applocaldata-write -> This allows non-recursive write access to the `$APPLOCALDATA` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-applocaldata-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-applocaldata-write-recursive -> This allows full recursive write access to the complete `$APPLOCALDATA` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-applocaldata-write-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-applog-meta -> This allows non-recursive read access to metadata of the `$APPLOG` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-applog-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-applog-meta-recursive -> This allows full recursive read access to metadata of the `$APPLOG` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-applog-meta-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-applog-read -> This allows non-recursive read access to the `$APPLOG` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-applog-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-applog-read-recursive -> This allows full recursive read access to the complete `$APPLOG` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-applog-read-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-applog-write -> This allows non-recursive write access to the `$APPLOG` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-applog-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-applog-write-recursive -> This allows full recursive write access to the complete `$APPLOG` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-applog-write-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-audio-meta -> This allows non-recursive read access to metadata of the `$AUDIO` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-audio-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-audio-meta-recursive -> This allows full recursive read access to metadata of the `$AUDIO` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-audio-meta-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-audio-read -> This allows non-recursive read access to the `$AUDIO` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-audio-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-audio-read-recursive -> This allows full recursive read access to the complete `$AUDIO` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-audio-read-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-audio-write -> This allows non-recursive write access to the `$AUDIO` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-audio-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-audio-write-recursive -> This allows full recursive write access to the complete `$AUDIO` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-audio-write-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-cache-meta -> This allows non-recursive read access to metadata of the `$CACHE` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-cache-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-cache-meta-recursive -> This allows full recursive read access to metadata of the `$CACHE` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-cache-meta-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-cache-read -> This allows non-recursive read access to the `$CACHE` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-cache-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-cache-read-recursive -> This allows full recursive read access to the complete `$CACHE` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-cache-read-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-cache-write -> This allows non-recursive write access to the `$CACHE` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-cache-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-cache-write-recursive -> This allows full recursive write access to the complete `$CACHE` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-cache-write-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-config-meta -> This allows non-recursive read access to metadata of the `$CONFIG` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-config-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-config-meta-recursive -> This allows full recursive read access to metadata of the `$CONFIG` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-config-meta-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-config-read -> This allows non-recursive read access to the `$CONFIG` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-config-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-config-read-recursive -> This allows full recursive read access to the complete `$CONFIG` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-config-read-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-config-write -> This allows non-recursive write access to the `$CONFIG` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-config-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-config-write-recursive -> This allows full recursive write access to the complete `$CONFIG` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-config-write-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-data-meta -> This allows non-recursive read access to metadata of the `$DATA` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-data-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-data-meta-recursive -> This allows full recursive read access to metadata of the `$DATA` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-data-meta-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-data-read -> This allows non-recursive read access to the `$DATA` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-data-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-data-read-recursive -> This allows full recursive read access to the complete `$DATA` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-data-read-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-data-write -> This allows non-recursive write access to the `$DATA` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-data-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-data-write-recursive -> This allows full recursive write access to the complete `$DATA` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-data-write-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-desktop-meta -> This allows non-recursive read access to metadata of the `$DESKTOP` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-desktop-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-desktop-meta-recursive -> This allows full recursive read access to metadata of the `$DESKTOP` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-desktop-meta-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-desktop-read -> This allows non-recursive read access to the `$DESKTOP` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-desktop-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-desktop-read-recursive -> This allows full recursive read access to the complete `$DESKTOP` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-desktop-read-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-desktop-write -> This allows non-recursive write access to the `$DESKTOP` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-desktop-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-desktop-write-recursive -> This allows full recursive write access to the complete `$DESKTOP` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-desktop-write-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-document-meta -> This allows non-recursive read access to metadata of the `$DOCUMENT` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-document-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-document-meta-recursive -> This allows full recursive read access to metadata of the `$DOCUMENT` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-document-meta-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-document-read -> This allows non-recursive read access to the `$DOCUMENT` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-document-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-document-read-recursive -> This allows full recursive read access to the complete `$DOCUMENT` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-document-read-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-document-write -> This allows non-recursive write access to the `$DOCUMENT` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-document-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-document-write-recursive -> This allows full recursive write access to the complete `$DOCUMENT` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-document-write-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-download-meta -> This allows non-recursive read access to metadata of the `$DOWNLOAD` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-download-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-download-meta-recursive -> This allows full recursive read access to metadata of the `$DOWNLOAD` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-download-meta-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-download-read -> This allows non-recursive read access to the `$DOWNLOAD` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-download-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-download-read-recursive -> This allows full recursive read access to the complete `$DOWNLOAD` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-download-read-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-download-write -> This allows non-recursive write access to the `$DOWNLOAD` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-download-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-download-write-recursive -> This allows full recursive write access to the complete `$DOWNLOAD` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-download-write-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-exe-meta -> This allows non-recursive read access to metadata of the `$EXE` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-exe-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-exe-meta-recursive -> This allows full recursive read access to metadata of the `$EXE` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-exe-meta-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-exe-read -> This allows non-recursive read access to the `$EXE` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-exe-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-exe-read-recursive -> This allows full recursive read access to the complete `$EXE` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-exe-read-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-exe-write -> This allows non-recursive write access to the `$EXE` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-exe-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-exe-write-recursive -> This allows full recursive write access to the complete `$EXE` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-exe-write-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-font-meta -> This allows non-recursive read access to metadata of the `$FONT` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-font-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-font-meta-recursive -> This allows full recursive read access to metadata of the `$FONT` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-font-meta-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-font-read -> This allows non-recursive read access to the `$FONT` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-font-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-font-read-recursive -> This allows full recursive read access to the complete `$FONT` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-font-read-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-font-write -> This allows non-recursive write access to the `$FONT` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-font-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-font-write-recursive -> This allows full recursive write access to the complete `$FONT` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-font-write-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-home-meta -> This allows non-recursive read access to metadata of the `$HOME` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-home-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-home-meta-recursive -> This allows full recursive read access to metadata of the `$HOME` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-home-meta-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-home-read -> This allows non-recursive read access to the `$HOME` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-home-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-home-read-recursive -> This allows full recursive read access to the complete `$HOME` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-home-read-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-home-write -> This allows non-recursive write access to the `$HOME` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-home-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-home-write-recursive -> This allows full recursive write access to the complete `$HOME` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-home-write-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-localdata-meta -> This allows non-recursive read access to metadata of the `$LOCALDATA` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-localdata-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-localdata-meta-recursive -> This allows full recursive read access to metadata of the `$LOCALDATA` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-localdata-meta-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-localdata-read -> This allows non-recursive read access to the `$LOCALDATA` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-localdata-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-localdata-read-recursive -> This allows full recursive read access to the complete `$LOCALDATA` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-localdata-read-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-localdata-write -> This allows non-recursive write access to the `$LOCALDATA` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-localdata-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-localdata-write-recursive -> This allows full recursive write access to the complete `$LOCALDATA` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-localdata-write-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-log-meta -> This allows non-recursive read access to metadata of the `$LOG` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-log-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-log-meta-recursive -> This allows full recursive read access to metadata of the `$LOG` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-log-meta-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-log-read -> This allows non-recursive read access to the `$LOG` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-log-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-log-read-recursive -> This allows full recursive read access to the complete `$LOG` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-log-read-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-log-write -> This allows non-recursive write access to the `$LOG` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-log-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-log-write-recursive -> This allows full recursive write access to the complete `$LOG` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-log-write-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-picture-meta -> This allows non-recursive read access to metadata of the `$PICTURE` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-picture-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-picture-meta-recursive -> This allows full recursive read access to metadata of the `$PICTURE` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-picture-meta-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-picture-read -> This allows non-recursive read access to the `$PICTURE` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-picture-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-picture-read-recursive -> This allows full recursive read access to the complete `$PICTURE` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-picture-read-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-picture-write -> This allows non-recursive write access to the `$PICTURE` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-picture-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-picture-write-recursive -> This allows full recursive write access to the complete `$PICTURE` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-picture-write-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-public-meta -> This allows non-recursive read access to metadata of the `$PUBLIC` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-public-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-public-meta-recursive -> This allows full recursive read access to metadata of the `$PUBLIC` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-public-meta-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-public-read -> This allows non-recursive read access to the `$PUBLIC` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-public-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-public-read-recursive -> This allows full recursive read access to the complete `$PUBLIC` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-public-read-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-public-write -> This allows non-recursive write access to the `$PUBLIC` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-public-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-public-write-recursive -> This allows full recursive write access to the complete `$PUBLIC` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-public-write-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-resource-meta -> This allows non-recursive read access to metadata of the `$RESOURCE` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-resource-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-resource-meta-recursive -> This allows full recursive read access to metadata of the `$RESOURCE` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-resource-meta-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-resource-read -> This allows non-recursive read access to the `$RESOURCE` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-resource-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-resource-read-recursive -> This allows full recursive read access to the complete `$RESOURCE` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-resource-read-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-resource-write -> This allows non-recursive write access to the `$RESOURCE` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-resource-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-resource-write-recursive -> This allows full recursive write access to the complete `$RESOURCE` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-resource-write-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-runtime-meta -> This allows non-recursive read access to metadata of the `$RUNTIME` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-runtime-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-runtime-meta-recursive -> This allows full recursive read access to metadata of the `$RUNTIME` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-runtime-meta-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-runtime-read -> This allows non-recursive read access to the `$RUNTIME` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-runtime-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-runtime-read-recursive -> This allows full recursive read access to the complete `$RUNTIME` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-runtime-read-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-runtime-write -> This allows non-recursive write access to the `$RUNTIME` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-runtime-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-runtime-write-recursive -> This allows full recursive write access to the complete `$RUNTIME` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-runtime-write-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-temp-meta -> This allows non-recursive read access to metadata of the `$TEMP` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-temp-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-temp-meta-recursive -> This allows full recursive read access to metadata of the `$TEMP` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-temp-meta-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-temp-read -> This allows non-recursive read access to the `$TEMP` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-temp-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-temp-read-recursive -> This allows full recursive read access to the complete `$TEMP` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-temp-read-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-temp-write -> This allows non-recursive write access to the `$TEMP` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-temp-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-temp-write-recursive -> This allows full recursive write access to the complete `$TEMP` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-temp-write-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-template-meta -> This allows non-recursive read access to metadata of the `$TEMPLATE` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-template-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-template-meta-recursive -> This allows full recursive read access to metadata of the `$TEMPLATE` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-template-meta-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-template-read -> This allows non-recursive read access to the `$TEMPLATE` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-template-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-template-read-recursive -> This allows full recursive read access to the complete `$TEMPLATE` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-template-read-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-template-write -> This allows non-recursive write access to the `$TEMPLATE` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-template-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-template-write-recursive -> This allows full recursive write access to the complete `$TEMPLATE` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-template-write-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-video-meta -> This allows non-recursive read access to metadata of the `$VIDEO` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-video-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-video-meta-recursive -> This allows full recursive read access to metadata of the `$VIDEO` folder, including file listing and statistics.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-video-meta-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-video-read -> This allows non-recursive read access to the `$VIDEO` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-video-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-video-read-recursive -> This allows full recursive read access to the complete `$VIDEO` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-video-read-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-video-write -> This allows non-recursive write access to the `$VIDEO` folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-video-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-video-write-recursive -> This allows full recursive write access to the complete `$VIDEO` folder, files and subdirectories.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-video-write-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-default -> This denies access to dangerous Tauri relevant files and folders by default.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-default"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-copy-file -> Enables the copy_file command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-copy-file"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-create -> Enables the create command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-create"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-exists -> Enables the exists command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-exists"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-fstat -> Enables the fstat command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-fstat"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-ftruncate -> Enables the ftruncate command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-ftruncate"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-lstat -> Enables the lstat command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-lstat"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-mkdir -> Enables the mkdir command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-mkdir"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-open -> Enables the open command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-open"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-read -> Enables the read command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-read-dir -> Enables the read_dir command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-read-dir"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-read-file -> Enables the read_file command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-read-file"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-read-text-file -> Enables the read_text_file command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-read-text-file"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-read-text-file-lines -> Enables the read_text_file_lines command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-read-text-file-lines"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-read-text-file-lines-next -> Enables the read_text_file_lines_next command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-read-text-file-lines-next"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-remove -> Enables the remove command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-remove"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-rename -> Enables the rename command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-rename"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-seek -> Enables the seek command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-seek"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-stat -> Enables the stat command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-stat"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-truncate -> Enables the truncate command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-truncate"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-unwatch -> Enables the unwatch command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-unwatch"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-watch -> Enables the watch command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-watch"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-write -> Enables the write command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-write-file -> Enables the write_file command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-write-file"
+                      ]
+                    },
+                    {
+                      "description": "fs:allow-write-text-file -> Enables the write_text_file command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:allow-write-text-file"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-copy-file -> Denies the copy_file command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-copy-file"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-create -> Denies the create command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-create"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-exists -> Denies the exists command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-exists"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-fstat -> Denies the fstat command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-fstat"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-ftruncate -> Denies the ftruncate command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-ftruncate"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-lstat -> Denies the lstat command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-lstat"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-mkdir -> Denies the mkdir command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-mkdir"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-open -> Denies the open command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-open"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-read -> Denies the read command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-read"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-read-dir -> Denies the read_dir command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-read-dir"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-read-file -> Denies the read_file command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-read-file"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-read-text-file -> Denies the read_text_file command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-read-text-file"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-read-text-file-lines -> Denies the read_text_file_lines command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-read-text-file-lines"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-read-text-file-lines-next -> Denies the read_text_file_lines_next command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-read-text-file-lines-next"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-remove -> Denies the remove command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-remove"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-rename -> Denies the rename command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-rename"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-seek -> Denies the seek command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-seek"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-stat -> Denies the stat command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-stat"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-truncate -> Denies the truncate command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-truncate"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-unwatch -> Denies the unwatch command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-unwatch"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-watch -> Denies the watch command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-watch"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-webview-data-linux -> This denies read access to the\n`$APPLOCALDATA` folder on linux as the webview data and configuration values are stored here.\nAllowing access can lead to sensitive information disclosure and should be well considered.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-webview-data-linux"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-webview-data-windows -> This denies read access to the\n`$APPLOCALDATA/EBWebView` folder on windows as the webview data and configuration values are stored here.\nAllowing access can lead to sensitive information disclosure and should be well considered.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-webview-data-windows"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-write -> Denies the write command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-write"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-write-file -> Denies the write_file command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-write-file"
+                      ]
+                    },
+                    {
+                      "description": "fs:deny-write-text-file -> Denies the write_text_file command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:deny-write-text-file"
+                      ]
+                    },
+                    {
+                      "description": "fs:read-all -> This enables all read related commands without any pre-configured accessible paths.",
+                      "type": "string",
+                      "enum": [
+                        "fs:read-all"
+                      ]
+                    },
+                    {
+                      "description": "fs:read-dirs -> This enables directory read and file metadata related commands without any pre-configured accessible paths.",
+                      "type": "string",
+                      "enum": [
+                        "fs:read-dirs"
+                      ]
+                    },
+                    {
+                      "description": "fs:read-files -> This enables file read related commands without any pre-configured accessible paths.",
+                      "type": "string",
+                      "enum": [
+                        "fs:read-files"
+                      ]
+                    },
+                    {
+                      "description": "fs:read-meta -> This enables all index or metadata related commands without any pre-configured accessible paths.",
+                      "type": "string",
+                      "enum": [
+                        "fs:read-meta"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope -> An empty permission you can use to modify the global scope.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-app -> This scope permits access to all files and list content of top level directories in the `$APP`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-app"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-app-index -> This scope permits to list all files and folders in the `$APP`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-app-index"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-app-recursive -> This scope recursive access to the complete `$APP` folder, including sub directories and files.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-app-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-appcache -> This scope permits access to all files and list content of top level directories in the `$APPCACHE`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-appcache"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-appcache-index -> This scope permits to list all files and folders in the `$APPCACHE`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-appcache-index"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-appcache-recursive -> This scope recursive access to the complete `$APPCACHE` folder, including sub directories and files.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-appcache-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-appconfig -> This scope permits access to all files and list content of top level directories in the `$APPCONFIG`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-appconfig"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-appconfig-index -> This scope permits to list all files and folders in the `$APPCONFIG`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-appconfig-index"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-appconfig-recursive -> This scope recursive access to the complete `$APPCONFIG` folder, including sub directories and files.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-appconfig-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-appdata -> This scope permits access to all files and list content of top level directories in the `$APPDATA`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-appdata"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-appdata-index -> This scope permits to list all files and folders in the `$APPDATA`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-appdata-index"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-appdata-recursive -> This scope recursive access to the complete `$APPDATA` folder, including sub directories and files.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-appdata-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-applocaldata -> This scope permits access to all files and list content of top level directories in the `$APPLOCALDATA`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-applocaldata"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-applocaldata-index -> This scope permits to list all files and folders in the `$APPLOCALDATA`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-applocaldata-index"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-applocaldata-recursive -> This scope recursive access to the complete `$APPLOCALDATA` folder, including sub directories and files.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-applocaldata-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-applog -> This scope permits access to all files and list content of top level directories in the `$APPLOG`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-applog"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-applog-index -> This scope permits to list all files and folders in the `$APPLOG`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-applog-index"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-applog-recursive -> This scope recursive access to the complete `$APPLOG` folder, including sub directories and files.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-applog-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-audio -> This scope permits access to all files and list content of top level directories in the `$AUDIO`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-audio"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-audio-index -> This scope permits to list all files and folders in the `$AUDIO`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-audio-index"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-audio-recursive -> This scope recursive access to the complete `$AUDIO` folder, including sub directories and files.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-audio-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-cache -> This scope permits access to all files and list content of top level directories in the `$CACHE`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-cache"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-cache-index -> This scope permits to list all files and folders in the `$CACHE`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-cache-index"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-cache-recursive -> This scope recursive access to the complete `$CACHE` folder, including sub directories and files.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-cache-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-config -> This scope permits access to all files and list content of top level directories in the `$CONFIG`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-config"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-config-index -> This scope permits to list all files and folders in the `$CONFIG`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-config-index"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-config-recursive -> This scope recursive access to the complete `$CONFIG` folder, including sub directories and files.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-config-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-data -> This scope permits access to all files and list content of top level directories in the `$DATA`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-data"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-data-index -> This scope permits to list all files and folders in the `$DATA`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-data-index"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-data-recursive -> This scope recursive access to the complete `$DATA` folder, including sub directories and files.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-data-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-desktop -> This scope permits access to all files and list content of top level directories in the `$DESKTOP`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-desktop"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-desktop-index -> This scope permits to list all files and folders in the `$DESKTOP`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-desktop-index"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-desktop-recursive -> This scope recursive access to the complete `$DESKTOP` folder, including sub directories and files.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-desktop-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-document -> This scope permits access to all files and list content of top level directories in the `$DOCUMENT`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-document"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-document-index -> This scope permits to list all files and folders in the `$DOCUMENT`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-document-index"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-document-recursive -> This scope recursive access to the complete `$DOCUMENT` folder, including sub directories and files.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-document-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-download -> This scope permits access to all files and list content of top level directories in the `$DOWNLOAD`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-download"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-download-index -> This scope permits to list all files and folders in the `$DOWNLOAD`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-download-index"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-download-recursive -> This scope recursive access to the complete `$DOWNLOAD` folder, including sub directories and files.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-download-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-exe -> This scope permits access to all files and list content of top level directories in the `$EXE`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-exe"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-exe-index -> This scope permits to list all files and folders in the `$EXE`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-exe-index"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-exe-recursive -> This scope recursive access to the complete `$EXE` folder, including sub directories and files.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-exe-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-font -> This scope permits access to all files and list content of top level directories in the `$FONT`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-font"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-font-index -> This scope permits to list all files and folders in the `$FONT`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-font-index"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-font-recursive -> This scope recursive access to the complete `$FONT` folder, including sub directories and files.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-font-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-home -> This scope permits access to all files and list content of top level directories in the `$HOME`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-home"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-home-index -> This scope permits to list all files and folders in the `$HOME`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-home-index"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-home-recursive -> This scope recursive access to the complete `$HOME` folder, including sub directories and files.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-home-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-localdata -> This scope permits access to all files and list content of top level directories in the `$LOCALDATA`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-localdata"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-localdata-index -> This scope permits to list all files and folders in the `$LOCALDATA`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-localdata-index"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-localdata-recursive -> This scope recursive access to the complete `$LOCALDATA` folder, including sub directories and files.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-localdata-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-log -> This scope permits access to all files and list content of top level directories in the `$LOG`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-log"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-log-index -> This scope permits to list all files and folders in the `$LOG`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-log-index"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-log-recursive -> This scope recursive access to the complete `$LOG` folder, including sub directories and files.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-log-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-picture -> This scope permits access to all files and list content of top level directories in the `$PICTURE`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-picture"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-picture-index -> This scope permits to list all files and folders in the `$PICTURE`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-picture-index"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-picture-recursive -> This scope recursive access to the complete `$PICTURE` folder, including sub directories and files.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-picture-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-public -> This scope permits access to all files and list content of top level directories in the `$PUBLIC`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-public"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-public-index -> This scope permits to list all files and folders in the `$PUBLIC`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-public-index"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-public-recursive -> This scope recursive access to the complete `$PUBLIC` folder, including sub directories and files.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-public-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-resource -> This scope permits access to all files and list content of top level directories in the `$RESOURCE`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-resource"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-resource-index -> This scope permits to list all files and folders in the `$RESOURCE`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-resource-index"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-resource-recursive -> This scope recursive access to the complete `$RESOURCE` folder, including sub directories and files.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-resource-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-runtime -> This scope permits access to all files and list content of top level directories in the `$RUNTIME`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-runtime"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-runtime-index -> This scope permits to list all files and folders in the `$RUNTIME`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-runtime-index"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-runtime-recursive -> This scope recursive access to the complete `$RUNTIME` folder, including sub directories and files.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-runtime-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-temp -> This scope permits access to all files and list content of top level directories in the `$TEMP`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-temp"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-temp-index -> This scope permits to list all files and folders in the `$TEMP`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-temp-index"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-temp-recursive -> This scope recursive access to the complete `$TEMP` folder, including sub directories and files.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-temp-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-template -> This scope permits access to all files and list content of top level directories in the `$TEMPLATE`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-template"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-template-index -> This scope permits to list all files and folders in the `$TEMPLATE`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-template-index"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-template-recursive -> This scope recursive access to the complete `$TEMPLATE` folder, including sub directories and files.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-template-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-video -> This scope permits access to all files and list content of top level directories in the `$VIDEO`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-video"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-video-index -> This scope permits to list all files and folders in the `$VIDEO`folder.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-video-index"
+                      ]
+                    },
+                    {
+                      "description": "fs:scope-video-recursive -> This scope recursive access to the complete `$VIDEO` folder, including sub directories and files.",
+                      "type": "string",
+                      "enum": [
+                        "fs:scope-video-recursive"
+                      ]
+                    },
+                    {
+                      "description": "fs:write-all -> This enables all write related commands without any pre-configured accessible paths.",
+                      "type": "string",
+                      "enum": [
+                        "fs:write-all"
+                      ]
+                    },
+                    {
+                      "description": "fs:write-files -> This enables all file write related commands without any pre-configured accessible paths.",
+                      "type": "string",
+                      "enum": [
+                        "fs:write-files"
+                      ]
+                    }
+                  ]
+                },
+                "allow": {
+                  "items": {
+                    "title": "FsScopeEntry",
+                    "description": "FS scope entry.",
+                    "anyOf": [
+                      {
+                        "description": "FS scope path.",
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "path"
+                        ],
+                        "properties": {
+                          "path": {
+                            "description": "FS scope path.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "deny": {
+                  "items": {
+                    "title": "FsScopeEntry",
+                    "description": "FS scope entry.",
+                    "anyOf": [
+                      {
+                        "description": "FS scope path.",
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "path"
+                        ],
+                        "properties": {
+                          "path": {
+                            "description": "FS scope path.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "identifier"
+              ],
+              "properties": {
+                "identifier": {
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "shell:default"
+                      ]
+                    },
+                    {
+                      "description": "shell:allow-execute -> Enables the execute command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "shell:allow-execute"
+                      ]
+                    },
+                    {
+                      "description": "shell:allow-kill -> Enables the kill command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "shell:allow-kill"
+                      ]
+                    },
+                    {
+                      "description": "shell:allow-open -> Enables the open command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "shell:allow-open"
+                      ]
+                    },
+                    {
+                      "description": "shell:allow-spawn -> Enables the spawn command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "shell:allow-spawn"
+                      ]
+                    },
+                    {
+                      "description": "shell:allow-stdin-write -> Enables the stdin_write command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "shell:allow-stdin-write"
+                      ]
+                    },
+                    {
+                      "description": "shell:deny-execute -> Denies the execute command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "shell:deny-execute"
+                      ]
+                    },
+                    {
+                      "description": "shell:deny-kill -> Denies the kill command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "shell:deny-kill"
+                      ]
+                    },
+                    {
+                      "description": "shell:deny-open -> Denies the open command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "shell:deny-open"
+                      ]
+                    },
+                    {
+                      "description": "shell:deny-spawn -> Denies the spawn command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "shell:deny-spawn"
+                      ]
+                    },
+                    {
+                      "description": "shell:deny-stdin-write -> Denies the stdin_write command without any pre-configured scope.",
+                      "type": "string",
+                      "enum": [
+                        "shell:deny-stdin-write"
+                      ]
+                    }
+                  ]
+                },
+                "allow": {
+                  "items": {
+                    "title": "Entry",
+                    "description": "A command allowed to be executed by the webview API.",
+                    "type": "object",
+                    "required": [
+                      "args",
+                      "cmd",
+                      "name",
+                      "sidecar"
+                    ],
+                    "properties": {
+                      "args": {
+                        "description": "The allowed arguments for the command execution.",
+                        "allOf": [
+                          {
+                            "$ref": "#/definitions/ShellAllowedArgs"
+                          }
+                        ]
+                      },
+                      "cmd": {
+                        "description": "The command name. It can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$APP`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The name for this allowed shell command configuration.\n\nThis name will be used inside of the webview API to call this command along with any specified arguments.",
+                        "type": "string"
+                      },
+                      "sidecar": {
+                        "description": "If this command is a sidecar command.",
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                },
+                "deny": {
+                  "items": {
+                    "title": "Entry",
+                    "description": "A command allowed to be executed by the webview API.",
+                    "type": "object",
+                    "required": [
+                      "args",
+                      "cmd",
+                      "name",
+                      "sidecar"
+                    ],
+                    "properties": {
+                      "args": {
+                        "description": "The allowed arguments for the command execution.",
+                        "allOf": [
+                          {
+                            "$ref": "#/definitions/ShellAllowedArgs"
+                          }
+                        ]
+                      },
+                      "cmd": {
+                        "description": "The command name. It can start with a variable that resolves to a system base directory. The variables are: `$AUDIO`, `$CACHE`, `$CONFIG`, `$DATA`, `$LOCALDATA`, `$DESKTOP`, `$DOCUMENT`, `$DOWNLOAD`, `$EXE`, `$FONT`, `$HOME`, `$PICTURE`, `$PUBLIC`, `$RUNTIME`, `$TEMPLATE`, `$VIDEO`, `$RESOURCE`, `$APP`, `$LOG`, `$TEMP`, `$APPCONFIG`, `$APPDATA`, `$APPLOCALDATA`, `$APPCACHE`, `$APPLOG`.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "The name for this allowed shell command configuration.\n\nThis name will be used inside of the webview API to call this command along with any specified arguments.",
+                        "type": "string"
+                      },
+                      "sidecar": {
+                        "description": "If this command is a sidecar command.",
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "Identifier": {
+      "oneOf": [
+        {
+          "description": "app:default -> Default permissions for the plugin.",
+          "type": "string",
+          "enum": [
+            "app:default"
+          ]
+        },
+        {
+          "description": "app:allow-app-hide -> Enables the app_hide command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "app:allow-app-hide"
+          ]
+        },
+        {
+          "description": "app:allow-app-show -> Enables the app_show command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "app:allow-app-show"
+          ]
+        },
+        {
+          "description": "app:allow-name -> Enables the name command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "app:allow-name"
+          ]
+        },
+        {
+          "description": "app:allow-tauri-version -> Enables the tauri_version command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "app:allow-tauri-version"
+          ]
+        },
+        {
+          "description": "app:allow-version -> Enables the version command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "app:allow-version"
+          ]
+        },
+        {
+          "description": "app:deny-app-hide -> Denies the app_hide command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "app:deny-app-hide"
+          ]
+        },
+        {
+          "description": "app:deny-app-show -> Denies the app_show command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "app:deny-app-show"
+          ]
+        },
+        {
+          "description": "app:deny-name -> Denies the name command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "app:deny-name"
+          ]
+        },
+        {
+          "description": "app:deny-tauri-version -> Denies the tauri_version command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "app:deny-tauri-version"
+          ]
+        },
+        {
+          "description": "app:deny-version -> Denies the version command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "app:deny-version"
+          ]
+        },
+        {
+          "description": "event:default -> Default permissions for the plugin.",
+          "type": "string",
+          "enum": [
+            "event:default"
+          ]
+        },
+        {
+          "description": "event:allow-emit -> Enables the emit command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "event:allow-emit"
+          ]
+        },
+        {
+          "description": "event:allow-emit-to -> Enables the emit_to command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "event:allow-emit-to"
+          ]
+        },
+        {
+          "description": "event:allow-listen -> Enables the listen command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "event:allow-listen"
+          ]
+        },
+        {
+          "description": "event:allow-unlisten -> Enables the unlisten command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "event:allow-unlisten"
+          ]
+        },
+        {
+          "description": "event:deny-emit -> Denies the emit command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "event:deny-emit"
+          ]
+        },
+        {
+          "description": "event:deny-emit-to -> Denies the emit_to command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "event:deny-emit-to"
+          ]
+        },
+        {
+          "description": "event:deny-listen -> Denies the listen command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "event:deny-listen"
+          ]
+        },
+        {
+          "description": "event:deny-unlisten -> Denies the unlisten command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "event:deny-unlisten"
+          ]
+        },
+        {
+          "description": "fs:allow-app-meta -> This allows non-recursive read access to metadata of the `$APP` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-app-meta"
+          ]
+        },
+        {
+          "description": "fs:allow-app-meta-recursive -> This allows full recursive read access to metadata of the `$APP` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-app-meta-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-app-read -> This allows non-recursive read access to the `$APP` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-app-read"
+          ]
+        },
+        {
+          "description": "fs:allow-app-read-recursive -> This allows full recursive read access to the complete `$APP` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-app-read-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-app-write -> This allows non-recursive write access to the `$APP` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-app-write"
+          ]
+        },
+        {
+          "description": "fs:allow-app-write-recursive -> This allows full recursive write access to the complete `$APP` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-app-write-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-appcache-meta -> This allows non-recursive read access to metadata of the `$APPCACHE` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-appcache-meta"
+          ]
+        },
+        {
+          "description": "fs:allow-appcache-meta-recursive -> This allows full recursive read access to metadata of the `$APPCACHE` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-appcache-meta-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-appcache-read -> This allows non-recursive read access to the `$APPCACHE` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-appcache-read"
+          ]
+        },
+        {
+          "description": "fs:allow-appcache-read-recursive -> This allows full recursive read access to the complete `$APPCACHE` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-appcache-read-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-appcache-write -> This allows non-recursive write access to the `$APPCACHE` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-appcache-write"
+          ]
+        },
+        {
+          "description": "fs:allow-appcache-write-recursive -> This allows full recursive write access to the complete `$APPCACHE` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-appcache-write-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-appconfig-meta -> This allows non-recursive read access to metadata of the `$APPCONFIG` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-appconfig-meta"
+          ]
+        },
+        {
+          "description": "fs:allow-appconfig-meta-recursive -> This allows full recursive read access to metadata of the `$APPCONFIG` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-appconfig-meta-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-appconfig-read -> This allows non-recursive read access to the `$APPCONFIG` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-appconfig-read"
+          ]
+        },
+        {
+          "description": "fs:allow-appconfig-read-recursive -> This allows full recursive read access to the complete `$APPCONFIG` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-appconfig-read-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-appconfig-write -> This allows non-recursive write access to the `$APPCONFIG` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-appconfig-write"
+          ]
+        },
+        {
+          "description": "fs:allow-appconfig-write-recursive -> This allows full recursive write access to the complete `$APPCONFIG` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-appconfig-write-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-appdata-meta -> This allows non-recursive read access to metadata of the `$APPDATA` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-appdata-meta"
+          ]
+        },
+        {
+          "description": "fs:allow-appdata-meta-recursive -> This allows full recursive read access to metadata of the `$APPDATA` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-appdata-meta-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-appdata-read -> This allows non-recursive read access to the `$APPDATA` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-appdata-read"
+          ]
+        },
+        {
+          "description": "fs:allow-appdata-read-recursive -> This allows full recursive read access to the complete `$APPDATA` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-appdata-read-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-appdata-write -> This allows non-recursive write access to the `$APPDATA` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-appdata-write"
+          ]
+        },
+        {
+          "description": "fs:allow-appdata-write-recursive -> This allows full recursive write access to the complete `$APPDATA` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-appdata-write-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-applocaldata-meta -> This allows non-recursive read access to metadata of the `$APPLOCALDATA` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-applocaldata-meta"
+          ]
+        },
+        {
+          "description": "fs:allow-applocaldata-meta-recursive -> This allows full recursive read access to metadata of the `$APPLOCALDATA` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-applocaldata-meta-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-applocaldata-read -> This allows non-recursive read access to the `$APPLOCALDATA` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-applocaldata-read"
+          ]
+        },
+        {
+          "description": "fs:allow-applocaldata-read-recursive -> This allows full recursive read access to the complete `$APPLOCALDATA` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-applocaldata-read-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-applocaldata-write -> This allows non-recursive write access to the `$APPLOCALDATA` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-applocaldata-write"
+          ]
+        },
+        {
+          "description": "fs:allow-applocaldata-write-recursive -> This allows full recursive write access to the complete `$APPLOCALDATA` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-applocaldata-write-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-applog-meta -> This allows non-recursive read access to metadata of the `$APPLOG` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-applog-meta"
+          ]
+        },
+        {
+          "description": "fs:allow-applog-meta-recursive -> This allows full recursive read access to metadata of the `$APPLOG` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-applog-meta-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-applog-read -> This allows non-recursive read access to the `$APPLOG` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-applog-read"
+          ]
+        },
+        {
+          "description": "fs:allow-applog-read-recursive -> This allows full recursive read access to the complete `$APPLOG` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-applog-read-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-applog-write -> This allows non-recursive write access to the `$APPLOG` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-applog-write"
+          ]
+        },
+        {
+          "description": "fs:allow-applog-write-recursive -> This allows full recursive write access to the complete `$APPLOG` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-applog-write-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-audio-meta -> This allows non-recursive read access to metadata of the `$AUDIO` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-audio-meta"
+          ]
+        },
+        {
+          "description": "fs:allow-audio-meta-recursive -> This allows full recursive read access to metadata of the `$AUDIO` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-audio-meta-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-audio-read -> This allows non-recursive read access to the `$AUDIO` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-audio-read"
+          ]
+        },
+        {
+          "description": "fs:allow-audio-read-recursive -> This allows full recursive read access to the complete `$AUDIO` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-audio-read-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-audio-write -> This allows non-recursive write access to the `$AUDIO` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-audio-write"
+          ]
+        },
+        {
+          "description": "fs:allow-audio-write-recursive -> This allows full recursive write access to the complete `$AUDIO` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-audio-write-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-cache-meta -> This allows non-recursive read access to metadata of the `$CACHE` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-cache-meta"
+          ]
+        },
+        {
+          "description": "fs:allow-cache-meta-recursive -> This allows full recursive read access to metadata of the `$CACHE` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-cache-meta-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-cache-read -> This allows non-recursive read access to the `$CACHE` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-cache-read"
+          ]
+        },
+        {
+          "description": "fs:allow-cache-read-recursive -> This allows full recursive read access to the complete `$CACHE` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-cache-read-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-cache-write -> This allows non-recursive write access to the `$CACHE` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-cache-write"
+          ]
+        },
+        {
+          "description": "fs:allow-cache-write-recursive -> This allows full recursive write access to the complete `$CACHE` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-cache-write-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-config-meta -> This allows non-recursive read access to metadata of the `$CONFIG` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-config-meta"
+          ]
+        },
+        {
+          "description": "fs:allow-config-meta-recursive -> This allows full recursive read access to metadata of the `$CONFIG` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-config-meta-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-config-read -> This allows non-recursive read access to the `$CONFIG` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-config-read"
+          ]
+        },
+        {
+          "description": "fs:allow-config-read-recursive -> This allows full recursive read access to the complete `$CONFIG` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-config-read-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-config-write -> This allows non-recursive write access to the `$CONFIG` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-config-write"
+          ]
+        },
+        {
+          "description": "fs:allow-config-write-recursive -> This allows full recursive write access to the complete `$CONFIG` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-config-write-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-data-meta -> This allows non-recursive read access to metadata of the `$DATA` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-data-meta"
+          ]
+        },
+        {
+          "description": "fs:allow-data-meta-recursive -> This allows full recursive read access to metadata of the `$DATA` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-data-meta-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-data-read -> This allows non-recursive read access to the `$DATA` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-data-read"
+          ]
+        },
+        {
+          "description": "fs:allow-data-read-recursive -> This allows full recursive read access to the complete `$DATA` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-data-read-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-data-write -> This allows non-recursive write access to the `$DATA` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-data-write"
+          ]
+        },
+        {
+          "description": "fs:allow-data-write-recursive -> This allows full recursive write access to the complete `$DATA` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-data-write-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-desktop-meta -> This allows non-recursive read access to metadata of the `$DESKTOP` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-desktop-meta"
+          ]
+        },
+        {
+          "description": "fs:allow-desktop-meta-recursive -> This allows full recursive read access to metadata of the `$DESKTOP` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-desktop-meta-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-desktop-read -> This allows non-recursive read access to the `$DESKTOP` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-desktop-read"
+          ]
+        },
+        {
+          "description": "fs:allow-desktop-read-recursive -> This allows full recursive read access to the complete `$DESKTOP` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-desktop-read-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-desktop-write -> This allows non-recursive write access to the `$DESKTOP` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-desktop-write"
+          ]
+        },
+        {
+          "description": "fs:allow-desktop-write-recursive -> This allows full recursive write access to the complete `$DESKTOP` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-desktop-write-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-document-meta -> This allows non-recursive read access to metadata of the `$DOCUMENT` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-document-meta"
+          ]
+        },
+        {
+          "description": "fs:allow-document-meta-recursive -> This allows full recursive read access to metadata of the `$DOCUMENT` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-document-meta-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-document-read -> This allows non-recursive read access to the `$DOCUMENT` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-document-read"
+          ]
+        },
+        {
+          "description": "fs:allow-document-read-recursive -> This allows full recursive read access to the complete `$DOCUMENT` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-document-read-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-document-write -> This allows non-recursive write access to the `$DOCUMENT` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-document-write"
+          ]
+        },
+        {
+          "description": "fs:allow-document-write-recursive -> This allows full recursive write access to the complete `$DOCUMENT` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-document-write-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-download-meta -> This allows non-recursive read access to metadata of the `$DOWNLOAD` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-download-meta"
+          ]
+        },
+        {
+          "description": "fs:allow-download-meta-recursive -> This allows full recursive read access to metadata of the `$DOWNLOAD` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-download-meta-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-download-read -> This allows non-recursive read access to the `$DOWNLOAD` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-download-read"
+          ]
+        },
+        {
+          "description": "fs:allow-download-read-recursive -> This allows full recursive read access to the complete `$DOWNLOAD` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-download-read-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-download-write -> This allows non-recursive write access to the `$DOWNLOAD` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-download-write"
+          ]
+        },
+        {
+          "description": "fs:allow-download-write-recursive -> This allows full recursive write access to the complete `$DOWNLOAD` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-download-write-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-exe-meta -> This allows non-recursive read access to metadata of the `$EXE` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-exe-meta"
+          ]
+        },
+        {
+          "description": "fs:allow-exe-meta-recursive -> This allows full recursive read access to metadata of the `$EXE` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-exe-meta-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-exe-read -> This allows non-recursive read access to the `$EXE` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-exe-read"
+          ]
+        },
+        {
+          "description": "fs:allow-exe-read-recursive -> This allows full recursive read access to the complete `$EXE` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-exe-read-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-exe-write -> This allows non-recursive write access to the `$EXE` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-exe-write"
+          ]
+        },
+        {
+          "description": "fs:allow-exe-write-recursive -> This allows full recursive write access to the complete `$EXE` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-exe-write-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-font-meta -> This allows non-recursive read access to metadata of the `$FONT` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-font-meta"
+          ]
+        },
+        {
+          "description": "fs:allow-font-meta-recursive -> This allows full recursive read access to metadata of the `$FONT` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-font-meta-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-font-read -> This allows non-recursive read access to the `$FONT` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-font-read"
+          ]
+        },
+        {
+          "description": "fs:allow-font-read-recursive -> This allows full recursive read access to the complete `$FONT` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-font-read-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-font-write -> This allows non-recursive write access to the `$FONT` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-font-write"
+          ]
+        },
+        {
+          "description": "fs:allow-font-write-recursive -> This allows full recursive write access to the complete `$FONT` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-font-write-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-home-meta -> This allows non-recursive read access to metadata of the `$HOME` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-home-meta"
+          ]
+        },
+        {
+          "description": "fs:allow-home-meta-recursive -> This allows full recursive read access to metadata of the `$HOME` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-home-meta-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-home-read -> This allows non-recursive read access to the `$HOME` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-home-read"
+          ]
+        },
+        {
+          "description": "fs:allow-home-read-recursive -> This allows full recursive read access to the complete `$HOME` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-home-read-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-home-write -> This allows non-recursive write access to the `$HOME` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-home-write"
+          ]
+        },
+        {
+          "description": "fs:allow-home-write-recursive -> This allows full recursive write access to the complete `$HOME` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-home-write-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-localdata-meta -> This allows non-recursive read access to metadata of the `$LOCALDATA` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-localdata-meta"
+          ]
+        },
+        {
+          "description": "fs:allow-localdata-meta-recursive -> This allows full recursive read access to metadata of the `$LOCALDATA` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-localdata-meta-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-localdata-read -> This allows non-recursive read access to the `$LOCALDATA` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-localdata-read"
+          ]
+        },
+        {
+          "description": "fs:allow-localdata-read-recursive -> This allows full recursive read access to the complete `$LOCALDATA` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-localdata-read-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-localdata-write -> This allows non-recursive write access to the `$LOCALDATA` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-localdata-write"
+          ]
+        },
+        {
+          "description": "fs:allow-localdata-write-recursive -> This allows full recursive write access to the complete `$LOCALDATA` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-localdata-write-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-log-meta -> This allows non-recursive read access to metadata of the `$LOG` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-log-meta"
+          ]
+        },
+        {
+          "description": "fs:allow-log-meta-recursive -> This allows full recursive read access to metadata of the `$LOG` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-log-meta-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-log-read -> This allows non-recursive read access to the `$LOG` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-log-read"
+          ]
+        },
+        {
+          "description": "fs:allow-log-read-recursive -> This allows full recursive read access to the complete `$LOG` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-log-read-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-log-write -> This allows non-recursive write access to the `$LOG` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-log-write"
+          ]
+        },
+        {
+          "description": "fs:allow-log-write-recursive -> This allows full recursive write access to the complete `$LOG` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-log-write-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-picture-meta -> This allows non-recursive read access to metadata of the `$PICTURE` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-picture-meta"
+          ]
+        },
+        {
+          "description": "fs:allow-picture-meta-recursive -> This allows full recursive read access to metadata of the `$PICTURE` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-picture-meta-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-picture-read -> This allows non-recursive read access to the `$PICTURE` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-picture-read"
+          ]
+        },
+        {
+          "description": "fs:allow-picture-read-recursive -> This allows full recursive read access to the complete `$PICTURE` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-picture-read-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-picture-write -> This allows non-recursive write access to the `$PICTURE` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-picture-write"
+          ]
+        },
+        {
+          "description": "fs:allow-picture-write-recursive -> This allows full recursive write access to the complete `$PICTURE` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-picture-write-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-public-meta -> This allows non-recursive read access to metadata of the `$PUBLIC` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-public-meta"
+          ]
+        },
+        {
+          "description": "fs:allow-public-meta-recursive -> This allows full recursive read access to metadata of the `$PUBLIC` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-public-meta-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-public-read -> This allows non-recursive read access to the `$PUBLIC` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-public-read"
+          ]
+        },
+        {
+          "description": "fs:allow-public-read-recursive -> This allows full recursive read access to the complete `$PUBLIC` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-public-read-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-public-write -> This allows non-recursive write access to the `$PUBLIC` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-public-write"
+          ]
+        },
+        {
+          "description": "fs:allow-public-write-recursive -> This allows full recursive write access to the complete `$PUBLIC` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-public-write-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-resource-meta -> This allows non-recursive read access to metadata of the `$RESOURCE` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-resource-meta"
+          ]
+        },
+        {
+          "description": "fs:allow-resource-meta-recursive -> This allows full recursive read access to metadata of the `$RESOURCE` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-resource-meta-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-resource-read -> This allows non-recursive read access to the `$RESOURCE` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-resource-read"
+          ]
+        },
+        {
+          "description": "fs:allow-resource-read-recursive -> This allows full recursive read access to the complete `$RESOURCE` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-resource-read-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-resource-write -> This allows non-recursive write access to the `$RESOURCE` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-resource-write"
+          ]
+        },
+        {
+          "description": "fs:allow-resource-write-recursive -> This allows full recursive write access to the complete `$RESOURCE` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-resource-write-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-runtime-meta -> This allows non-recursive read access to metadata of the `$RUNTIME` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-runtime-meta"
+          ]
+        },
+        {
+          "description": "fs:allow-runtime-meta-recursive -> This allows full recursive read access to metadata of the `$RUNTIME` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-runtime-meta-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-runtime-read -> This allows non-recursive read access to the `$RUNTIME` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-runtime-read"
+          ]
+        },
+        {
+          "description": "fs:allow-runtime-read-recursive -> This allows full recursive read access to the complete `$RUNTIME` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-runtime-read-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-runtime-write -> This allows non-recursive write access to the `$RUNTIME` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-runtime-write"
+          ]
+        },
+        {
+          "description": "fs:allow-runtime-write-recursive -> This allows full recursive write access to the complete `$RUNTIME` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-runtime-write-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-temp-meta -> This allows non-recursive read access to metadata of the `$TEMP` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-temp-meta"
+          ]
+        },
+        {
+          "description": "fs:allow-temp-meta-recursive -> This allows full recursive read access to metadata of the `$TEMP` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-temp-meta-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-temp-read -> This allows non-recursive read access to the `$TEMP` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-temp-read"
+          ]
+        },
+        {
+          "description": "fs:allow-temp-read-recursive -> This allows full recursive read access to the complete `$TEMP` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-temp-read-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-temp-write -> This allows non-recursive write access to the `$TEMP` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-temp-write"
+          ]
+        },
+        {
+          "description": "fs:allow-temp-write-recursive -> This allows full recursive write access to the complete `$TEMP` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-temp-write-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-template-meta -> This allows non-recursive read access to metadata of the `$TEMPLATE` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-template-meta"
+          ]
+        },
+        {
+          "description": "fs:allow-template-meta-recursive -> This allows full recursive read access to metadata of the `$TEMPLATE` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-template-meta-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-template-read -> This allows non-recursive read access to the `$TEMPLATE` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-template-read"
+          ]
+        },
+        {
+          "description": "fs:allow-template-read-recursive -> This allows full recursive read access to the complete `$TEMPLATE` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-template-read-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-template-write -> This allows non-recursive write access to the `$TEMPLATE` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-template-write"
+          ]
+        },
+        {
+          "description": "fs:allow-template-write-recursive -> This allows full recursive write access to the complete `$TEMPLATE` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-template-write-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-video-meta -> This allows non-recursive read access to metadata of the `$VIDEO` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-video-meta"
+          ]
+        },
+        {
+          "description": "fs:allow-video-meta-recursive -> This allows full recursive read access to metadata of the `$VIDEO` folder, including file listing and statistics.",
+          "type": "string",
+          "enum": [
+            "fs:allow-video-meta-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-video-read -> This allows non-recursive read access to the `$VIDEO` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-video-read"
+          ]
+        },
+        {
+          "description": "fs:allow-video-read-recursive -> This allows full recursive read access to the complete `$VIDEO` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-video-read-recursive"
+          ]
+        },
+        {
+          "description": "fs:allow-video-write -> This allows non-recursive write access to the `$VIDEO` folder.",
+          "type": "string",
+          "enum": [
+            "fs:allow-video-write"
+          ]
+        },
+        {
+          "description": "fs:allow-video-write-recursive -> This allows full recursive write access to the complete `$VIDEO` folder, files and subdirectories.",
+          "type": "string",
+          "enum": [
+            "fs:allow-video-write-recursive"
+          ]
+        },
+        {
+          "description": "fs:deny-default -> This denies access to dangerous Tauri relevant files and folders by default.",
+          "type": "string",
+          "enum": [
+            "fs:deny-default"
+          ]
+        },
+        {
+          "description": "fs:default -> # Tauri `fs` default permissions\n\nThis configuration file defines the default permissions granted\nto the filesystem.\n\n### Granted Permissions\n\nThis default permission set enables all read-related commands and\nallows access to the `$APP` folder and sub directories created in it.\nThe location of the `$APP` folder depends on the operating system,\nwhere the application is run.\n\nIn general the `$APP` folder needs to be manually created\nby the application at runtime, before accessing files or folders\nin it is possible.\n\n### Denied Permissions\n\nThis default permission set prevents access to critical components\nof the Tauri application by default.\nOn Windows the webview data folder access is denied.\n\n",
+          "type": "string",
+          "enum": [
+            "fs:default"
+          ]
+        },
+        {
+          "description": "fs:allow-copy-file -> Enables the copy_file command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:allow-copy-file"
+          ]
+        },
+        {
+          "description": "fs:allow-create -> Enables the create command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:allow-create"
+          ]
+        },
+        {
+          "description": "fs:allow-exists -> Enables the exists command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:allow-exists"
+          ]
+        },
+        {
+          "description": "fs:allow-fstat -> Enables the fstat command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:allow-fstat"
+          ]
+        },
+        {
+          "description": "fs:allow-ftruncate -> Enables the ftruncate command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:allow-ftruncate"
+          ]
+        },
+        {
+          "description": "fs:allow-lstat -> Enables the lstat command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:allow-lstat"
+          ]
+        },
+        {
+          "description": "fs:allow-mkdir -> Enables the mkdir command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:allow-mkdir"
+          ]
+        },
+        {
+          "description": "fs:allow-open -> Enables the open command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:allow-open"
+          ]
+        },
+        {
+          "description": "fs:allow-read -> Enables the read command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:allow-read"
+          ]
+        },
+        {
+          "description": "fs:allow-read-dir -> Enables the read_dir command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:allow-read-dir"
+          ]
+        },
+        {
+          "description": "fs:allow-read-file -> Enables the read_file command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:allow-read-file"
+          ]
+        },
+        {
+          "description": "fs:allow-read-text-file -> Enables the read_text_file command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:allow-read-text-file"
+          ]
+        },
+        {
+          "description": "fs:allow-read-text-file-lines -> Enables the read_text_file_lines command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:allow-read-text-file-lines"
+          ]
+        },
+        {
+          "description": "fs:allow-read-text-file-lines-next -> Enables the read_text_file_lines_next command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:allow-read-text-file-lines-next"
+          ]
+        },
+        {
+          "description": "fs:allow-remove -> Enables the remove command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:allow-remove"
+          ]
+        },
+        {
+          "description": "fs:allow-rename -> Enables the rename command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:allow-rename"
+          ]
+        },
+        {
+          "description": "fs:allow-seek -> Enables the seek command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:allow-seek"
+          ]
+        },
+        {
+          "description": "fs:allow-stat -> Enables the stat command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:allow-stat"
+          ]
+        },
+        {
+          "description": "fs:allow-truncate -> Enables the truncate command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:allow-truncate"
+          ]
+        },
+        {
+          "description": "fs:allow-unwatch -> Enables the unwatch command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:allow-unwatch"
+          ]
+        },
+        {
+          "description": "fs:allow-watch -> Enables the watch command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:allow-watch"
+          ]
+        },
+        {
+          "description": "fs:allow-write -> Enables the write command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:allow-write"
+          ]
+        },
+        {
+          "description": "fs:allow-write-file -> Enables the write_file command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:allow-write-file"
+          ]
+        },
+        {
+          "description": "fs:allow-write-text-file -> Enables the write_text_file command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:allow-write-text-file"
+          ]
+        },
+        {
+          "description": "fs:deny-copy-file -> Denies the copy_file command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:deny-copy-file"
+          ]
+        },
+        {
+          "description": "fs:deny-create -> Denies the create command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:deny-create"
+          ]
+        },
+        {
+          "description": "fs:deny-exists -> Denies the exists command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:deny-exists"
+          ]
+        },
+        {
+          "description": "fs:deny-fstat -> Denies the fstat command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:deny-fstat"
+          ]
+        },
+        {
+          "description": "fs:deny-ftruncate -> Denies the ftruncate command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:deny-ftruncate"
+          ]
+        },
+        {
+          "description": "fs:deny-lstat -> Denies the lstat command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:deny-lstat"
+          ]
+        },
+        {
+          "description": "fs:deny-mkdir -> Denies the mkdir command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:deny-mkdir"
+          ]
+        },
+        {
+          "description": "fs:deny-open -> Denies the open command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:deny-open"
+          ]
+        },
+        {
+          "description": "fs:deny-read -> Denies the read command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:deny-read"
+          ]
+        },
+        {
+          "description": "fs:deny-read-dir -> Denies the read_dir command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:deny-read-dir"
+          ]
+        },
+        {
+          "description": "fs:deny-read-file -> Denies the read_file command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:deny-read-file"
+          ]
+        },
+        {
+          "description": "fs:deny-read-text-file -> Denies the read_text_file command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:deny-read-text-file"
+          ]
+        },
+        {
+          "description": "fs:deny-read-text-file-lines -> Denies the read_text_file_lines command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:deny-read-text-file-lines"
+          ]
+        },
+        {
+          "description": "fs:deny-read-text-file-lines-next -> Denies the read_text_file_lines_next command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:deny-read-text-file-lines-next"
+          ]
+        },
+        {
+          "description": "fs:deny-remove -> Denies the remove command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:deny-remove"
+          ]
+        },
+        {
+          "description": "fs:deny-rename -> Denies the rename command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:deny-rename"
+          ]
+        },
+        {
+          "description": "fs:deny-seek -> Denies the seek command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:deny-seek"
+          ]
+        },
+        {
+          "description": "fs:deny-stat -> Denies the stat command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:deny-stat"
+          ]
+        },
+        {
+          "description": "fs:deny-truncate -> Denies the truncate command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:deny-truncate"
+          ]
+        },
+        {
+          "description": "fs:deny-unwatch -> Denies the unwatch command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:deny-unwatch"
+          ]
+        },
+        {
+          "description": "fs:deny-watch -> Denies the watch command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:deny-watch"
+          ]
+        },
+        {
+          "description": "fs:deny-webview-data-linux -> This denies read access to the\n`$APPLOCALDATA` folder on linux as the webview data and configuration values are stored here.\nAllowing access can lead to sensitive information disclosure and should be well considered.",
+          "type": "string",
+          "enum": [
+            "fs:deny-webview-data-linux"
+          ]
+        },
+        {
+          "description": "fs:deny-webview-data-windows -> This denies read access to the\n`$APPLOCALDATA/EBWebView` folder on windows as the webview data and configuration values are stored here.\nAllowing access can lead to sensitive information disclosure and should be well considered.",
+          "type": "string",
+          "enum": [
+            "fs:deny-webview-data-windows"
+          ]
+        },
+        {
+          "description": "fs:deny-write -> Denies the write command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:deny-write"
+          ]
+        },
+        {
+          "description": "fs:deny-write-file -> Denies the write_file command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:deny-write-file"
+          ]
+        },
+        {
+          "description": "fs:deny-write-text-file -> Denies the write_text_file command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "fs:deny-write-text-file"
+          ]
+        },
+        {
+          "description": "fs:read-all -> This enables all read related commands without any pre-configured accessible paths.",
+          "type": "string",
+          "enum": [
+            "fs:read-all"
+          ]
+        },
+        {
+          "description": "fs:read-dirs -> This enables directory read and file metadata related commands without any pre-configured accessible paths.",
+          "type": "string",
+          "enum": [
+            "fs:read-dirs"
+          ]
+        },
+        {
+          "description": "fs:read-files -> This enables file read related commands without any pre-configured accessible paths.",
+          "type": "string",
+          "enum": [
+            "fs:read-files"
+          ]
+        },
+        {
+          "description": "fs:read-meta -> This enables all index or metadata related commands without any pre-configured accessible paths.",
+          "type": "string",
+          "enum": [
+            "fs:read-meta"
+          ]
+        },
+        {
+          "description": "fs:scope -> An empty permission you can use to modify the global scope.",
+          "type": "string",
+          "enum": [
+            "fs:scope"
+          ]
+        },
+        {
+          "description": "fs:scope-app -> This scope permits access to all files and list content of top level directories in the `$APP`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-app"
+          ]
+        },
+        {
+          "description": "fs:scope-app-index -> This scope permits to list all files and folders in the `$APP`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-app-index"
+          ]
+        },
+        {
+          "description": "fs:scope-app-recursive -> This scope recursive access to the complete `$APP` folder, including sub directories and files.",
+          "type": "string",
+          "enum": [
+            "fs:scope-app-recursive"
+          ]
+        },
+        {
+          "description": "fs:scope-appcache -> This scope permits access to all files and list content of top level directories in the `$APPCACHE`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-appcache"
+          ]
+        },
+        {
+          "description": "fs:scope-appcache-index -> This scope permits to list all files and folders in the `$APPCACHE`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-appcache-index"
+          ]
+        },
+        {
+          "description": "fs:scope-appcache-recursive -> This scope recursive access to the complete `$APPCACHE` folder, including sub directories and files.",
+          "type": "string",
+          "enum": [
+            "fs:scope-appcache-recursive"
+          ]
+        },
+        {
+          "description": "fs:scope-appconfig -> This scope permits access to all files and list content of top level directories in the `$APPCONFIG`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-appconfig"
+          ]
+        },
+        {
+          "description": "fs:scope-appconfig-index -> This scope permits to list all files and folders in the `$APPCONFIG`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-appconfig-index"
+          ]
+        },
+        {
+          "description": "fs:scope-appconfig-recursive -> This scope recursive access to the complete `$APPCONFIG` folder, including sub directories and files.",
+          "type": "string",
+          "enum": [
+            "fs:scope-appconfig-recursive"
+          ]
+        },
+        {
+          "description": "fs:scope-appdata -> This scope permits access to all files and list content of top level directories in the `$APPDATA`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-appdata"
+          ]
+        },
+        {
+          "description": "fs:scope-appdata-index -> This scope permits to list all files and folders in the `$APPDATA`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-appdata-index"
+          ]
+        },
+        {
+          "description": "fs:scope-appdata-recursive -> This scope recursive access to the complete `$APPDATA` folder, including sub directories and files.",
+          "type": "string",
+          "enum": [
+            "fs:scope-appdata-recursive"
+          ]
+        },
+        {
+          "description": "fs:scope-applocaldata -> This scope permits access to all files and list content of top level directories in the `$APPLOCALDATA`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-applocaldata"
+          ]
+        },
+        {
+          "description": "fs:scope-applocaldata-index -> This scope permits to list all files and folders in the `$APPLOCALDATA`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-applocaldata-index"
+          ]
+        },
+        {
+          "description": "fs:scope-applocaldata-recursive -> This scope recursive access to the complete `$APPLOCALDATA` folder, including sub directories and files.",
+          "type": "string",
+          "enum": [
+            "fs:scope-applocaldata-recursive"
+          ]
+        },
+        {
+          "description": "fs:scope-applog -> This scope permits access to all files and list content of top level directories in the `$APPLOG`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-applog"
+          ]
+        },
+        {
+          "description": "fs:scope-applog-index -> This scope permits to list all files and folders in the `$APPLOG`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-applog-index"
+          ]
+        },
+        {
+          "description": "fs:scope-applog-recursive -> This scope recursive access to the complete `$APPLOG` folder, including sub directories and files.",
+          "type": "string",
+          "enum": [
+            "fs:scope-applog-recursive"
+          ]
+        },
+        {
+          "description": "fs:scope-audio -> This scope permits access to all files and list content of top level directories in the `$AUDIO`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-audio"
+          ]
+        },
+        {
+          "description": "fs:scope-audio-index -> This scope permits to list all files and folders in the `$AUDIO`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-audio-index"
+          ]
+        },
+        {
+          "description": "fs:scope-audio-recursive -> This scope recursive access to the complete `$AUDIO` folder, including sub directories and files.",
+          "type": "string",
+          "enum": [
+            "fs:scope-audio-recursive"
+          ]
+        },
+        {
+          "description": "fs:scope-cache -> This scope permits access to all files and list content of top level directories in the `$CACHE`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-cache"
+          ]
+        },
+        {
+          "description": "fs:scope-cache-index -> This scope permits to list all files and folders in the `$CACHE`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-cache-index"
+          ]
+        },
+        {
+          "description": "fs:scope-cache-recursive -> This scope recursive access to the complete `$CACHE` folder, including sub directories and files.",
+          "type": "string",
+          "enum": [
+            "fs:scope-cache-recursive"
+          ]
+        },
+        {
+          "description": "fs:scope-config -> This scope permits access to all files and list content of top level directories in the `$CONFIG`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-config"
+          ]
+        },
+        {
+          "description": "fs:scope-config-index -> This scope permits to list all files and folders in the `$CONFIG`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-config-index"
+          ]
+        },
+        {
+          "description": "fs:scope-config-recursive -> This scope recursive access to the complete `$CONFIG` folder, including sub directories and files.",
+          "type": "string",
+          "enum": [
+            "fs:scope-config-recursive"
+          ]
+        },
+        {
+          "description": "fs:scope-data -> This scope permits access to all files and list content of top level directories in the `$DATA`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-data"
+          ]
+        },
+        {
+          "description": "fs:scope-data-index -> This scope permits to list all files and folders in the `$DATA`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-data-index"
+          ]
+        },
+        {
+          "description": "fs:scope-data-recursive -> This scope recursive access to the complete `$DATA` folder, including sub directories and files.",
+          "type": "string",
+          "enum": [
+            "fs:scope-data-recursive"
+          ]
+        },
+        {
+          "description": "fs:scope-desktop -> This scope permits access to all files and list content of top level directories in the `$DESKTOP`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-desktop"
+          ]
+        },
+        {
+          "description": "fs:scope-desktop-index -> This scope permits to list all files and folders in the `$DESKTOP`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-desktop-index"
+          ]
+        },
+        {
+          "description": "fs:scope-desktop-recursive -> This scope recursive access to the complete `$DESKTOP` folder, including sub directories and files.",
+          "type": "string",
+          "enum": [
+            "fs:scope-desktop-recursive"
+          ]
+        },
+        {
+          "description": "fs:scope-document -> This scope permits access to all files and list content of top level directories in the `$DOCUMENT`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-document"
+          ]
+        },
+        {
+          "description": "fs:scope-document-index -> This scope permits to list all files and folders in the `$DOCUMENT`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-document-index"
+          ]
+        },
+        {
+          "description": "fs:scope-document-recursive -> This scope recursive access to the complete `$DOCUMENT` folder, including sub directories and files.",
+          "type": "string",
+          "enum": [
+            "fs:scope-document-recursive"
+          ]
+        },
+        {
+          "description": "fs:scope-download -> This scope permits access to all files and list content of top level directories in the `$DOWNLOAD`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-download"
+          ]
+        },
+        {
+          "description": "fs:scope-download-index -> This scope permits to list all files and folders in the `$DOWNLOAD`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-download-index"
+          ]
+        },
+        {
+          "description": "fs:scope-download-recursive -> This scope recursive access to the complete `$DOWNLOAD` folder, including sub directories and files.",
+          "type": "string",
+          "enum": [
+            "fs:scope-download-recursive"
+          ]
+        },
+        {
+          "description": "fs:scope-exe -> This scope permits access to all files and list content of top level directories in the `$EXE`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-exe"
+          ]
+        },
+        {
+          "description": "fs:scope-exe-index -> This scope permits to list all files and folders in the `$EXE`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-exe-index"
+          ]
+        },
+        {
+          "description": "fs:scope-exe-recursive -> This scope recursive access to the complete `$EXE` folder, including sub directories and files.",
+          "type": "string",
+          "enum": [
+            "fs:scope-exe-recursive"
+          ]
+        },
+        {
+          "description": "fs:scope-font -> This scope permits access to all files and list content of top level directories in the `$FONT`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-font"
+          ]
+        },
+        {
+          "description": "fs:scope-font-index -> This scope permits to list all files and folders in the `$FONT`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-font-index"
+          ]
+        },
+        {
+          "description": "fs:scope-font-recursive -> This scope recursive access to the complete `$FONT` folder, including sub directories and files.",
+          "type": "string",
+          "enum": [
+            "fs:scope-font-recursive"
+          ]
+        },
+        {
+          "description": "fs:scope-home -> This scope permits access to all files and list content of top level directories in the `$HOME`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-home"
+          ]
+        },
+        {
+          "description": "fs:scope-home-index -> This scope permits to list all files and folders in the `$HOME`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-home-index"
+          ]
+        },
+        {
+          "description": "fs:scope-home-recursive -> This scope recursive access to the complete `$HOME` folder, including sub directories and files.",
+          "type": "string",
+          "enum": [
+            "fs:scope-home-recursive"
+          ]
+        },
+        {
+          "description": "fs:scope-localdata -> This scope permits access to all files and list content of top level directories in the `$LOCALDATA`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-localdata"
+          ]
+        },
+        {
+          "description": "fs:scope-localdata-index -> This scope permits to list all files and folders in the `$LOCALDATA`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-localdata-index"
+          ]
+        },
+        {
+          "description": "fs:scope-localdata-recursive -> This scope recursive access to the complete `$LOCALDATA` folder, including sub directories and files.",
+          "type": "string",
+          "enum": [
+            "fs:scope-localdata-recursive"
+          ]
+        },
+        {
+          "description": "fs:scope-log -> This scope permits access to all files and list content of top level directories in the `$LOG`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-log"
+          ]
+        },
+        {
+          "description": "fs:scope-log-index -> This scope permits to list all files and folders in the `$LOG`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-log-index"
+          ]
+        },
+        {
+          "description": "fs:scope-log-recursive -> This scope recursive access to the complete `$LOG` folder, including sub directories and files.",
+          "type": "string",
+          "enum": [
+            "fs:scope-log-recursive"
+          ]
+        },
+        {
+          "description": "fs:scope-picture -> This scope permits access to all files and list content of top level directories in the `$PICTURE`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-picture"
+          ]
+        },
+        {
+          "description": "fs:scope-picture-index -> This scope permits to list all files and folders in the `$PICTURE`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-picture-index"
+          ]
+        },
+        {
+          "description": "fs:scope-picture-recursive -> This scope recursive access to the complete `$PICTURE` folder, including sub directories and files.",
+          "type": "string",
+          "enum": [
+            "fs:scope-picture-recursive"
+          ]
+        },
+        {
+          "description": "fs:scope-public -> This scope permits access to all files and list content of top level directories in the `$PUBLIC`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-public"
+          ]
+        },
+        {
+          "description": "fs:scope-public-index -> This scope permits to list all files and folders in the `$PUBLIC`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-public-index"
+          ]
+        },
+        {
+          "description": "fs:scope-public-recursive -> This scope recursive access to the complete `$PUBLIC` folder, including sub directories and files.",
+          "type": "string",
+          "enum": [
+            "fs:scope-public-recursive"
+          ]
+        },
+        {
+          "description": "fs:scope-resource -> This scope permits access to all files and list content of top level directories in the `$RESOURCE`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-resource"
+          ]
+        },
+        {
+          "description": "fs:scope-resource-index -> This scope permits to list all files and folders in the `$RESOURCE`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-resource-index"
+          ]
+        },
+        {
+          "description": "fs:scope-resource-recursive -> This scope recursive access to the complete `$RESOURCE` folder, including sub directories and files.",
+          "type": "string",
+          "enum": [
+            "fs:scope-resource-recursive"
+          ]
+        },
+        {
+          "description": "fs:scope-runtime -> This scope permits access to all files and list content of top level directories in the `$RUNTIME`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-runtime"
+          ]
+        },
+        {
+          "description": "fs:scope-runtime-index -> This scope permits to list all files and folders in the `$RUNTIME`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-runtime-index"
+          ]
+        },
+        {
+          "description": "fs:scope-runtime-recursive -> This scope recursive access to the complete `$RUNTIME` folder, including sub directories and files.",
+          "type": "string",
+          "enum": [
+            "fs:scope-runtime-recursive"
+          ]
+        },
+        {
+          "description": "fs:scope-temp -> This scope permits access to all files and list content of top level directories in the `$TEMP`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-temp"
+          ]
+        },
+        {
+          "description": "fs:scope-temp-index -> This scope permits to list all files and folders in the `$TEMP`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-temp-index"
+          ]
+        },
+        {
+          "description": "fs:scope-temp-recursive -> This scope recursive access to the complete `$TEMP` folder, including sub directories and files.",
+          "type": "string",
+          "enum": [
+            "fs:scope-temp-recursive"
+          ]
+        },
+        {
+          "description": "fs:scope-template -> This scope permits access to all files and list content of top level directories in the `$TEMPLATE`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-template"
+          ]
+        },
+        {
+          "description": "fs:scope-template-index -> This scope permits to list all files and folders in the `$TEMPLATE`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-template-index"
+          ]
+        },
+        {
+          "description": "fs:scope-template-recursive -> This scope recursive access to the complete `$TEMPLATE` folder, including sub directories and files.",
+          "type": "string",
+          "enum": [
+            "fs:scope-template-recursive"
+          ]
+        },
+        {
+          "description": "fs:scope-video -> This scope permits access to all files and list content of top level directories in the `$VIDEO`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-video"
+          ]
+        },
+        {
+          "description": "fs:scope-video-index -> This scope permits to list all files and folders in the `$VIDEO`folder.",
+          "type": "string",
+          "enum": [
+            "fs:scope-video-index"
+          ]
+        },
+        {
+          "description": "fs:scope-video-recursive -> This scope recursive access to the complete `$VIDEO` folder, including sub directories and files.",
+          "type": "string",
+          "enum": [
+            "fs:scope-video-recursive"
+          ]
+        },
+        {
+          "description": "fs:write-all -> This enables all write related commands without any pre-configured accessible paths.",
+          "type": "string",
+          "enum": [
+            "fs:write-all"
+          ]
+        },
+        {
+          "description": "fs:write-files -> This enables all file write related commands without any pre-configured accessible paths.",
+          "type": "string",
+          "enum": [
+            "fs:write-files"
+          ]
+        },
+        {
+          "description": "image:default -> Default permissions for the plugin.",
+          "type": "string",
+          "enum": [
+            "image:default"
+          ]
+        },
+        {
+          "description": "image:allow-from-bytes -> Enables the from_bytes command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "image:allow-from-bytes"
+          ]
+        },
+        {
+          "description": "image:allow-from-path -> Enables the from_path command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "image:allow-from-path"
+          ]
+        },
+        {
+          "description": "image:allow-new -> Enables the new command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "image:allow-new"
+          ]
+        },
+        {
+          "description": "image:allow-rgba -> Enables the rgba command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "image:allow-rgba"
+          ]
+        },
+        {
+          "description": "image:allow-size -> Enables the size command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "image:allow-size"
+          ]
+        },
+        {
+          "description": "image:deny-from-bytes -> Denies the from_bytes command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "image:deny-from-bytes"
+          ]
+        },
+        {
+          "description": "image:deny-from-path -> Denies the from_path command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "image:deny-from-path"
+          ]
+        },
+        {
+          "description": "image:deny-new -> Denies the new command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "image:deny-new"
+          ]
+        },
+        {
+          "description": "image:deny-rgba -> Denies the rgba command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "image:deny-rgba"
+          ]
+        },
+        {
+          "description": "image:deny-size -> Denies the size command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "image:deny-size"
+          ]
+        },
+        {
+          "description": "menu:default -> Default permissions for the plugin.",
+          "type": "string",
+          "enum": [
+            "menu:default"
+          ]
+        },
+        {
+          "description": "menu:allow-append -> Enables the append command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:allow-append"
+          ]
+        },
+        {
+          "description": "menu:allow-create-default -> Enables the create_default command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:allow-create-default"
+          ]
+        },
+        {
+          "description": "menu:allow-get -> Enables the get command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:allow-get"
+          ]
+        },
+        {
+          "description": "menu:allow-insert -> Enables the insert command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:allow-insert"
+          ]
+        },
+        {
+          "description": "menu:allow-is-checked -> Enables the is_checked command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:allow-is-checked"
+          ]
+        },
+        {
+          "description": "menu:allow-is-enabled -> Enables the is_enabled command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:allow-is-enabled"
+          ]
+        },
+        {
+          "description": "menu:allow-items -> Enables the items command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:allow-items"
+          ]
+        },
+        {
+          "description": "menu:allow-new -> Enables the new command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:allow-new"
+          ]
+        },
+        {
+          "description": "menu:allow-popup -> Enables the popup command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:allow-popup"
+          ]
+        },
+        {
+          "description": "menu:allow-prepend -> Enables the prepend command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:allow-prepend"
+          ]
+        },
+        {
+          "description": "menu:allow-remove -> Enables the remove command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:allow-remove"
+          ]
+        },
+        {
+          "description": "menu:allow-remove-at -> Enables the remove_at command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:allow-remove-at"
+          ]
+        },
+        {
+          "description": "menu:allow-set-accelerator -> Enables the set_accelerator command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:allow-set-accelerator"
+          ]
+        },
+        {
+          "description": "menu:allow-set-as-app-menu -> Enables the set_as_app_menu command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:allow-set-as-app-menu"
+          ]
+        },
+        {
+          "description": "menu:allow-set-as-help-menu-for-nsapp -> Enables the set_as_help_menu_for_nsapp command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:allow-set-as-help-menu-for-nsapp"
+          ]
+        },
+        {
+          "description": "menu:allow-set-as-window-menu -> Enables the set_as_window_menu command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:allow-set-as-window-menu"
+          ]
+        },
+        {
+          "description": "menu:allow-set-as-windows-menu-for-nsapp -> Enables the set_as_windows_menu_for_nsapp command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:allow-set-as-windows-menu-for-nsapp"
+          ]
+        },
+        {
+          "description": "menu:allow-set-checked -> Enables the set_checked command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:allow-set-checked"
+          ]
+        },
+        {
+          "description": "menu:allow-set-enabled -> Enables the set_enabled command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:allow-set-enabled"
+          ]
+        },
+        {
+          "description": "menu:allow-set-icon -> Enables the set_icon command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:allow-set-icon"
+          ]
+        },
+        {
+          "description": "menu:allow-set-text -> Enables the set_text command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:allow-set-text"
+          ]
+        },
+        {
+          "description": "menu:allow-text -> Enables the text command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:allow-text"
+          ]
+        },
+        {
+          "description": "menu:deny-append -> Denies the append command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:deny-append"
+          ]
+        },
+        {
+          "description": "menu:deny-create-default -> Denies the create_default command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:deny-create-default"
+          ]
+        },
+        {
+          "description": "menu:deny-get -> Denies the get command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:deny-get"
+          ]
+        },
+        {
+          "description": "menu:deny-insert -> Denies the insert command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:deny-insert"
+          ]
+        },
+        {
+          "description": "menu:deny-is-checked -> Denies the is_checked command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:deny-is-checked"
+          ]
+        },
+        {
+          "description": "menu:deny-is-enabled -> Denies the is_enabled command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:deny-is-enabled"
+          ]
+        },
+        {
+          "description": "menu:deny-items -> Denies the items command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:deny-items"
+          ]
+        },
+        {
+          "description": "menu:deny-new -> Denies the new command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:deny-new"
+          ]
+        },
+        {
+          "description": "menu:deny-popup -> Denies the popup command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:deny-popup"
+          ]
+        },
+        {
+          "description": "menu:deny-prepend -> Denies the prepend command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:deny-prepend"
+          ]
+        },
+        {
+          "description": "menu:deny-remove -> Denies the remove command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:deny-remove"
+          ]
+        },
+        {
+          "description": "menu:deny-remove-at -> Denies the remove_at command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:deny-remove-at"
+          ]
+        },
+        {
+          "description": "menu:deny-set-accelerator -> Denies the set_accelerator command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:deny-set-accelerator"
+          ]
+        },
+        {
+          "description": "menu:deny-set-as-app-menu -> Denies the set_as_app_menu command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:deny-set-as-app-menu"
+          ]
+        },
+        {
+          "description": "menu:deny-set-as-help-menu-for-nsapp -> Denies the set_as_help_menu_for_nsapp command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:deny-set-as-help-menu-for-nsapp"
+          ]
+        },
+        {
+          "description": "menu:deny-set-as-window-menu -> Denies the set_as_window_menu command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:deny-set-as-window-menu"
+          ]
+        },
+        {
+          "description": "menu:deny-set-as-windows-menu-for-nsapp -> Denies the set_as_windows_menu_for_nsapp command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:deny-set-as-windows-menu-for-nsapp"
+          ]
+        },
+        {
+          "description": "menu:deny-set-checked -> Denies the set_checked command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:deny-set-checked"
+          ]
+        },
+        {
+          "description": "menu:deny-set-enabled -> Denies the set_enabled command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:deny-set-enabled"
+          ]
+        },
+        {
+          "description": "menu:deny-set-icon -> Denies the set_icon command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:deny-set-icon"
+          ]
+        },
+        {
+          "description": "menu:deny-set-text -> Denies the set_text command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:deny-set-text"
+          ]
+        },
+        {
+          "description": "menu:deny-text -> Denies the text command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "menu:deny-text"
+          ]
+        },
+        {
+          "description": "path:default -> Default permissions for the plugin.",
+          "type": "string",
+          "enum": [
+            "path:default"
+          ]
+        },
+        {
+          "description": "path:allow-basename -> Enables the basename command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "path:allow-basename"
+          ]
+        },
+        {
+          "description": "path:allow-dirname -> Enables the dirname command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "path:allow-dirname"
+          ]
+        },
+        {
+          "description": "path:allow-extname -> Enables the extname command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "path:allow-extname"
+          ]
+        },
+        {
+          "description": "path:allow-is-absolute -> Enables the is_absolute command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "path:allow-is-absolute"
+          ]
+        },
+        {
+          "description": "path:allow-join -> Enables the join command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "path:allow-join"
+          ]
+        },
+        {
+          "description": "path:allow-normalize -> Enables the normalize command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "path:allow-normalize"
+          ]
+        },
+        {
+          "description": "path:allow-resolve -> Enables the resolve command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "path:allow-resolve"
+          ]
+        },
+        {
+          "description": "path:allow-resolve-directory -> Enables the resolve_directory command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "path:allow-resolve-directory"
+          ]
+        },
+        {
+          "description": "path:deny-basename -> Denies the basename command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "path:deny-basename"
+          ]
+        },
+        {
+          "description": "path:deny-dirname -> Denies the dirname command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "path:deny-dirname"
+          ]
+        },
+        {
+          "description": "path:deny-extname -> Denies the extname command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "path:deny-extname"
+          ]
+        },
+        {
+          "description": "path:deny-is-absolute -> Denies the is_absolute command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "path:deny-is-absolute"
+          ]
+        },
+        {
+          "description": "path:deny-join -> Denies the join command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "path:deny-join"
+          ]
+        },
+        {
+          "description": "path:deny-normalize -> Denies the normalize command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "path:deny-normalize"
+          ]
+        },
+        {
+          "description": "path:deny-resolve -> Denies the resolve command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "path:deny-resolve"
+          ]
+        },
+        {
+          "description": "path:deny-resolve-directory -> Denies the resolve_directory command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "path:deny-resolve-directory"
+          ]
+        },
+        {
+          "description": "resources:default -> Default permissions for the plugin.",
+          "type": "string",
+          "enum": [
+            "resources:default"
+          ]
+        },
+        {
+          "description": "resources:allow-close -> Enables the close command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "resources:allow-close"
+          ]
+        },
+        {
+          "description": "resources:deny-close -> Denies the close command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "resources:deny-close"
+          ]
+        },
+        {
+          "type": "string",
+          "enum": [
+            "shell:default"
+          ]
+        },
+        {
+          "description": "shell:allow-execute -> Enables the execute command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "shell:allow-execute"
+          ]
+        },
+        {
+          "description": "shell:allow-kill -> Enables the kill command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "shell:allow-kill"
+          ]
+        },
+        {
+          "description": "shell:allow-open -> Enables the open command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "shell:allow-open"
+          ]
+        },
+        {
+          "description": "shell:allow-spawn -> Enables the spawn command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "shell:allow-spawn"
+          ]
+        },
+        {
+          "description": "shell:allow-stdin-write -> Enables the stdin_write command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "shell:allow-stdin-write"
+          ]
+        },
+        {
+          "description": "shell:deny-execute -> Denies the execute command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "shell:deny-execute"
+          ]
+        },
+        {
+          "description": "shell:deny-kill -> Denies the kill command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "shell:deny-kill"
+          ]
+        },
+        {
+          "description": "shell:deny-open -> Denies the open command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "shell:deny-open"
+          ]
+        },
+        {
+          "description": "shell:deny-spawn -> Denies the spawn command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "shell:deny-spawn"
+          ]
+        },
+        {
+          "description": "shell:deny-stdin-write -> Denies the stdin_write command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "shell:deny-stdin-write"
+          ]
+        },
+        {
+          "description": "tray:default -> Default permissions for the plugin.",
+          "type": "string",
+          "enum": [
+            "tray:default"
+          ]
+        },
+        {
+          "description": "tray:allow-get-by-id -> Enables the get_by_id command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "tray:allow-get-by-id"
+          ]
+        },
+        {
+          "description": "tray:allow-new -> Enables the new command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "tray:allow-new"
+          ]
+        },
+        {
+          "description": "tray:allow-remove-by-id -> Enables the remove_by_id command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "tray:allow-remove-by-id"
+          ]
+        },
+        {
+          "description": "tray:allow-set-icon -> Enables the set_icon command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "tray:allow-set-icon"
+          ]
+        },
+        {
+          "description": "tray:allow-set-icon-as-template -> Enables the set_icon_as_template command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "tray:allow-set-icon-as-template"
+          ]
+        },
+        {
+          "description": "tray:allow-set-menu -> Enables the set_menu command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "tray:allow-set-menu"
+          ]
+        },
+        {
+          "description": "tray:allow-set-show-menu-on-left-click -> Enables the set_show_menu_on_left_click command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "tray:allow-set-show-menu-on-left-click"
+          ]
+        },
+        {
+          "description": "tray:allow-set-temp-dir-path -> Enables the set_temp_dir_path command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "tray:allow-set-temp-dir-path"
+          ]
+        },
+        {
+          "description": "tray:allow-set-title -> Enables the set_title command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "tray:allow-set-title"
+          ]
+        },
+        {
+          "description": "tray:allow-set-tooltip -> Enables the set_tooltip command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "tray:allow-set-tooltip"
+          ]
+        },
+        {
+          "description": "tray:allow-set-visible -> Enables the set_visible command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "tray:allow-set-visible"
+          ]
+        },
+        {
+          "description": "tray:deny-get-by-id -> Denies the get_by_id command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "tray:deny-get-by-id"
+          ]
+        },
+        {
+          "description": "tray:deny-new -> Denies the new command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "tray:deny-new"
+          ]
+        },
+        {
+          "description": "tray:deny-remove-by-id -> Denies the remove_by_id command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "tray:deny-remove-by-id"
+          ]
+        },
+        {
+          "description": "tray:deny-set-icon -> Denies the set_icon command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "tray:deny-set-icon"
+          ]
+        },
+        {
+          "description": "tray:deny-set-icon-as-template -> Denies the set_icon_as_template command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "tray:deny-set-icon-as-template"
+          ]
+        },
+        {
+          "description": "tray:deny-set-menu -> Denies the set_menu command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "tray:deny-set-menu"
+          ]
+        },
+        {
+          "description": "tray:deny-set-show-menu-on-left-click -> Denies the set_show_menu_on_left_click command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "tray:deny-set-show-menu-on-left-click"
+          ]
+        },
+        {
+          "description": "tray:deny-set-temp-dir-path -> Denies the set_temp_dir_path command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "tray:deny-set-temp-dir-path"
+          ]
+        },
+        {
+          "description": "tray:deny-set-title -> Denies the set_title command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "tray:deny-set-title"
+          ]
+        },
+        {
+          "description": "tray:deny-set-tooltip -> Denies the set_tooltip command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "tray:deny-set-tooltip"
+          ]
+        },
+        {
+          "description": "tray:deny-set-visible -> Denies the set_visible command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "tray:deny-set-visible"
+          ]
+        },
+        {
+          "description": "webview:default -> Default permissions for the plugin.",
+          "type": "string",
+          "enum": [
+            "webview:default"
+          ]
+        },
+        {
+          "description": "webview:allow-create-webview -> Enables the create_webview command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "webview:allow-create-webview"
+          ]
+        },
+        {
+          "description": "webview:allow-create-webview-window -> Enables the create_webview_window command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "webview:allow-create-webview-window"
+          ]
+        },
+        {
+          "description": "webview:allow-internal-toggle-devtools -> Enables the internal_toggle_devtools command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "webview:allow-internal-toggle-devtools"
+          ]
+        },
+        {
+          "description": "webview:allow-print -> Enables the print command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "webview:allow-print"
+          ]
+        },
+        {
+          "description": "webview:allow-reparent -> Enables the reparent command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "webview:allow-reparent"
+          ]
+        },
+        {
+          "description": "webview:allow-set-webview-focus -> Enables the set_webview_focus command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "webview:allow-set-webview-focus"
+          ]
+        },
+        {
+          "description": "webview:allow-set-webview-position -> Enables the set_webview_position command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "webview:allow-set-webview-position"
+          ]
+        },
+        {
+          "description": "webview:allow-set-webview-size -> Enables the set_webview_size command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "webview:allow-set-webview-size"
+          ]
+        },
+        {
+          "description": "webview:allow-set-webview-zoom -> Enables the set_webview_zoom command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "webview:allow-set-webview-zoom"
+          ]
+        },
+        {
+          "description": "webview:allow-webview-close -> Enables the webview_close command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "webview:allow-webview-close"
+          ]
+        },
+        {
+          "description": "webview:allow-webview-position -> Enables the webview_position command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "webview:allow-webview-position"
+          ]
+        },
+        {
+          "description": "webview:allow-webview-size -> Enables the webview_size command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "webview:allow-webview-size"
+          ]
+        },
+        {
+          "description": "webview:deny-create-webview -> Denies the create_webview command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "webview:deny-create-webview"
+          ]
+        },
+        {
+          "description": "webview:deny-create-webview-window -> Denies the create_webview_window command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "webview:deny-create-webview-window"
+          ]
+        },
+        {
+          "description": "webview:deny-internal-toggle-devtools -> Denies the internal_toggle_devtools command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "webview:deny-internal-toggle-devtools"
+          ]
+        },
+        {
+          "description": "webview:deny-print -> Denies the print command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "webview:deny-print"
+          ]
+        },
+        {
+          "description": "webview:deny-reparent -> Denies the reparent command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "webview:deny-reparent"
+          ]
+        },
+        {
+          "description": "webview:deny-set-webview-focus -> Denies the set_webview_focus command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "webview:deny-set-webview-focus"
+          ]
+        },
+        {
+          "description": "webview:deny-set-webview-position -> Denies the set_webview_position command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "webview:deny-set-webview-position"
+          ]
+        },
+        {
+          "description": "webview:deny-set-webview-size -> Denies the set_webview_size command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "webview:deny-set-webview-size"
+          ]
+        },
+        {
+          "description": "webview:deny-set-webview-zoom -> Denies the set_webview_zoom command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "webview:deny-set-webview-zoom"
+          ]
+        },
+        {
+          "description": "webview:deny-webview-close -> Denies the webview_close command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "webview:deny-webview-close"
+          ]
+        },
+        {
+          "description": "webview:deny-webview-position -> Denies the webview_position command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "webview:deny-webview-position"
+          ]
+        },
+        {
+          "description": "webview:deny-webview-size -> Denies the webview_size command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "webview:deny-webview-size"
+          ]
+        },
+        {
+          "description": "window:default -> Default permissions for the plugin.",
+          "type": "string",
+          "enum": [
+            "window:default"
+          ]
+        },
+        {
+          "description": "window:allow-available-monitors -> Enables the available_monitors command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-available-monitors"
+          ]
+        },
+        {
+          "description": "window:allow-center -> Enables the center command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-center"
+          ]
+        },
+        {
+          "description": "window:allow-close -> Enables the close command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-close"
+          ]
+        },
+        {
+          "description": "window:allow-create -> Enables the create command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-create"
+          ]
+        },
+        {
+          "description": "window:allow-current-monitor -> Enables the current_monitor command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-current-monitor"
+          ]
+        },
+        {
+          "description": "window:allow-cursor-position -> Enables the cursor_position command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-cursor-position"
+          ]
+        },
+        {
+          "description": "window:allow-destroy -> Enables the destroy command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-destroy"
+          ]
+        },
+        {
+          "description": "window:allow-hide -> Enables the hide command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-hide"
+          ]
+        },
+        {
+          "description": "window:allow-inner-position -> Enables the inner_position command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-inner-position"
+          ]
+        },
+        {
+          "description": "window:allow-inner-size -> Enables the inner_size command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-inner-size"
+          ]
+        },
+        {
+          "description": "window:allow-internal-toggle-maximize -> Enables the internal_toggle_maximize command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-internal-toggle-maximize"
+          ]
+        },
+        {
+          "description": "window:allow-is-closable -> Enables the is_closable command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-is-closable"
+          ]
+        },
+        {
+          "description": "window:allow-is-decorated -> Enables the is_decorated command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-is-decorated"
+          ]
+        },
+        {
+          "description": "window:allow-is-focused -> Enables the is_focused command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-is-focused"
+          ]
+        },
+        {
+          "description": "window:allow-is-fullscreen -> Enables the is_fullscreen command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-is-fullscreen"
+          ]
+        },
+        {
+          "description": "window:allow-is-maximizable -> Enables the is_maximizable command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-is-maximizable"
+          ]
+        },
+        {
+          "description": "window:allow-is-maximized -> Enables the is_maximized command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-is-maximized"
+          ]
+        },
+        {
+          "description": "window:allow-is-minimizable -> Enables the is_minimizable command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-is-minimizable"
+          ]
+        },
+        {
+          "description": "window:allow-is-minimized -> Enables the is_minimized command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-is-minimized"
+          ]
+        },
+        {
+          "description": "window:allow-is-resizable -> Enables the is_resizable command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-is-resizable"
+          ]
+        },
+        {
+          "description": "window:allow-is-visible -> Enables the is_visible command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-is-visible"
+          ]
+        },
+        {
+          "description": "window:allow-maximize -> Enables the maximize command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-maximize"
+          ]
+        },
+        {
+          "description": "window:allow-minimize -> Enables the minimize command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-minimize"
+          ]
+        },
+        {
+          "description": "window:allow-outer-position -> Enables the outer_position command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-outer-position"
+          ]
+        },
+        {
+          "description": "window:allow-outer-size -> Enables the outer_size command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-outer-size"
+          ]
+        },
+        {
+          "description": "window:allow-primary-monitor -> Enables the primary_monitor command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-primary-monitor"
+          ]
+        },
+        {
+          "description": "window:allow-request-user-attention -> Enables the request_user_attention command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-request-user-attention"
+          ]
+        },
+        {
+          "description": "window:allow-scale-factor -> Enables the scale_factor command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-scale-factor"
+          ]
+        },
+        {
+          "description": "window:allow-set-always-on-bottom -> Enables the set_always_on_bottom command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-always-on-bottom"
+          ]
+        },
+        {
+          "description": "window:allow-set-always-on-top -> Enables the set_always_on_top command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-always-on-top"
+          ]
+        },
+        {
+          "description": "window:allow-set-closable -> Enables the set_closable command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-closable"
+          ]
+        },
+        {
+          "description": "window:allow-set-content-protected -> Enables the set_content_protected command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-content-protected"
+          ]
+        },
+        {
+          "description": "window:allow-set-cursor-grab -> Enables the set_cursor_grab command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-cursor-grab"
+          ]
+        },
+        {
+          "description": "window:allow-set-cursor-icon -> Enables the set_cursor_icon command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-cursor-icon"
+          ]
+        },
+        {
+          "description": "window:allow-set-cursor-position -> Enables the set_cursor_position command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-cursor-position"
+          ]
+        },
+        {
+          "description": "window:allow-set-cursor-visible -> Enables the set_cursor_visible command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-cursor-visible"
+          ]
+        },
+        {
+          "description": "window:allow-set-decorations -> Enables the set_decorations command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-decorations"
+          ]
+        },
+        {
+          "description": "window:allow-set-effects -> Enables the set_effects command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-effects"
+          ]
+        },
+        {
+          "description": "window:allow-set-focus -> Enables the set_focus command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-focus"
+          ]
+        },
+        {
+          "description": "window:allow-set-fullscreen -> Enables the set_fullscreen command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-fullscreen"
+          ]
+        },
+        {
+          "description": "window:allow-set-icon -> Enables the set_icon command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-icon"
+          ]
+        },
+        {
+          "description": "window:allow-set-ignore-cursor-events -> Enables the set_ignore_cursor_events command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-ignore-cursor-events"
+          ]
+        },
+        {
+          "description": "window:allow-set-max-size -> Enables the set_max_size command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-max-size"
+          ]
+        },
+        {
+          "description": "window:allow-set-maximizable -> Enables the set_maximizable command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-maximizable"
+          ]
+        },
+        {
+          "description": "window:allow-set-min-size -> Enables the set_min_size command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-min-size"
+          ]
+        },
+        {
+          "description": "window:allow-set-minimizable -> Enables the set_minimizable command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-minimizable"
+          ]
+        },
+        {
+          "description": "window:allow-set-position -> Enables the set_position command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-position"
+          ]
+        },
+        {
+          "description": "window:allow-set-progress-bar -> Enables the set_progress_bar command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-progress-bar"
+          ]
+        },
+        {
+          "description": "window:allow-set-resizable -> Enables the set_resizable command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-resizable"
+          ]
+        },
+        {
+          "description": "window:allow-set-shadow -> Enables the set_shadow command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-shadow"
+          ]
+        },
+        {
+          "description": "window:allow-set-size -> Enables the set_size command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-size"
+          ]
+        },
+        {
+          "description": "window:allow-set-skip-taskbar -> Enables the set_skip_taskbar command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-skip-taskbar"
+          ]
+        },
+        {
+          "description": "window:allow-set-title -> Enables the set_title command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-title"
+          ]
+        },
+        {
+          "description": "window:allow-set-visible-on-all-workspaces -> Enables the set_visible_on_all_workspaces command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-set-visible-on-all-workspaces"
+          ]
+        },
+        {
+          "description": "window:allow-show -> Enables the show command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-show"
+          ]
+        },
+        {
+          "description": "window:allow-start-dragging -> Enables the start_dragging command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-start-dragging"
+          ]
+        },
+        {
+          "description": "window:allow-start-resize-dragging -> Enables the start_resize_dragging command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-start-resize-dragging"
+          ]
+        },
+        {
+          "description": "window:allow-theme -> Enables the theme command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-theme"
+          ]
+        },
+        {
+          "description": "window:allow-title -> Enables the title command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-title"
+          ]
+        },
+        {
+          "description": "window:allow-toggle-maximize -> Enables the toggle_maximize command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-toggle-maximize"
+          ]
+        },
+        {
+          "description": "window:allow-unmaximize -> Enables the unmaximize command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-unmaximize"
+          ]
+        },
+        {
+          "description": "window:allow-unminimize -> Enables the unminimize command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:allow-unminimize"
+          ]
+        },
+        {
+          "description": "window:deny-available-monitors -> Denies the available_monitors command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-available-monitors"
+          ]
+        },
+        {
+          "description": "window:deny-center -> Denies the center command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-center"
+          ]
+        },
+        {
+          "description": "window:deny-close -> Denies the close command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-close"
+          ]
+        },
+        {
+          "description": "window:deny-create -> Denies the create command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-create"
+          ]
+        },
+        {
+          "description": "window:deny-current-monitor -> Denies the current_monitor command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-current-monitor"
+          ]
+        },
+        {
+          "description": "window:deny-cursor-position -> Denies the cursor_position command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-cursor-position"
+          ]
+        },
+        {
+          "description": "window:deny-destroy -> Denies the destroy command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-destroy"
+          ]
+        },
+        {
+          "description": "window:deny-hide -> Denies the hide command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-hide"
+          ]
+        },
+        {
+          "description": "window:deny-inner-position -> Denies the inner_position command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-inner-position"
+          ]
+        },
+        {
+          "description": "window:deny-inner-size -> Denies the inner_size command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-inner-size"
+          ]
+        },
+        {
+          "description": "window:deny-internal-toggle-maximize -> Denies the internal_toggle_maximize command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-internal-toggle-maximize"
+          ]
+        },
+        {
+          "description": "window:deny-is-closable -> Denies the is_closable command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-is-closable"
+          ]
+        },
+        {
+          "description": "window:deny-is-decorated -> Denies the is_decorated command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-is-decorated"
+          ]
+        },
+        {
+          "description": "window:deny-is-focused -> Denies the is_focused command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-is-focused"
+          ]
+        },
+        {
+          "description": "window:deny-is-fullscreen -> Denies the is_fullscreen command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-is-fullscreen"
+          ]
+        },
+        {
+          "description": "window:deny-is-maximizable -> Denies the is_maximizable command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-is-maximizable"
+          ]
+        },
+        {
+          "description": "window:deny-is-maximized -> Denies the is_maximized command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-is-maximized"
+          ]
+        },
+        {
+          "description": "window:deny-is-minimizable -> Denies the is_minimizable command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-is-minimizable"
+          ]
+        },
+        {
+          "description": "window:deny-is-minimized -> Denies the is_minimized command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-is-minimized"
+          ]
+        },
+        {
+          "description": "window:deny-is-resizable -> Denies the is_resizable command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-is-resizable"
+          ]
+        },
+        {
+          "description": "window:deny-is-visible -> Denies the is_visible command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-is-visible"
+          ]
+        },
+        {
+          "description": "window:deny-maximize -> Denies the maximize command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-maximize"
+          ]
+        },
+        {
+          "description": "window:deny-minimize -> Denies the minimize command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-minimize"
+          ]
+        },
+        {
+          "description": "window:deny-outer-position -> Denies the outer_position command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-outer-position"
+          ]
+        },
+        {
+          "description": "window:deny-outer-size -> Denies the outer_size command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-outer-size"
+          ]
+        },
+        {
+          "description": "window:deny-primary-monitor -> Denies the primary_monitor command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-primary-monitor"
+          ]
+        },
+        {
+          "description": "window:deny-request-user-attention -> Denies the request_user_attention command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-request-user-attention"
+          ]
+        },
+        {
+          "description": "window:deny-scale-factor -> Denies the scale_factor command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-scale-factor"
+          ]
+        },
+        {
+          "description": "window:deny-set-always-on-bottom -> Denies the set_always_on_bottom command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-always-on-bottom"
+          ]
+        },
+        {
+          "description": "window:deny-set-always-on-top -> Denies the set_always_on_top command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-always-on-top"
+          ]
+        },
+        {
+          "description": "window:deny-set-closable -> Denies the set_closable command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-closable"
+          ]
+        },
+        {
+          "description": "window:deny-set-content-protected -> Denies the set_content_protected command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-content-protected"
+          ]
+        },
+        {
+          "description": "window:deny-set-cursor-grab -> Denies the set_cursor_grab command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-cursor-grab"
+          ]
+        },
+        {
+          "description": "window:deny-set-cursor-icon -> Denies the set_cursor_icon command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-cursor-icon"
+          ]
+        },
+        {
+          "description": "window:deny-set-cursor-position -> Denies the set_cursor_position command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-cursor-position"
+          ]
+        },
+        {
+          "description": "window:deny-set-cursor-visible -> Denies the set_cursor_visible command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-cursor-visible"
+          ]
+        },
+        {
+          "description": "window:deny-set-decorations -> Denies the set_decorations command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-decorations"
+          ]
+        },
+        {
+          "description": "window:deny-set-effects -> Denies the set_effects command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-effects"
+          ]
+        },
+        {
+          "description": "window:deny-set-focus -> Denies the set_focus command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-focus"
+          ]
+        },
+        {
+          "description": "window:deny-set-fullscreen -> Denies the set_fullscreen command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-fullscreen"
+          ]
+        },
+        {
+          "description": "window:deny-set-icon -> Denies the set_icon command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-icon"
+          ]
+        },
+        {
+          "description": "window:deny-set-ignore-cursor-events -> Denies the set_ignore_cursor_events command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-ignore-cursor-events"
+          ]
+        },
+        {
+          "description": "window:deny-set-max-size -> Denies the set_max_size command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-max-size"
+          ]
+        },
+        {
+          "description": "window:deny-set-maximizable -> Denies the set_maximizable command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-maximizable"
+          ]
+        },
+        {
+          "description": "window:deny-set-min-size -> Denies the set_min_size command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-min-size"
+          ]
+        },
+        {
+          "description": "window:deny-set-minimizable -> Denies the set_minimizable command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-minimizable"
+          ]
+        },
+        {
+          "description": "window:deny-set-position -> Denies the set_position command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-position"
+          ]
+        },
+        {
+          "description": "window:deny-set-progress-bar -> Denies the set_progress_bar command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-progress-bar"
+          ]
+        },
+        {
+          "description": "window:deny-set-resizable -> Denies the set_resizable command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-resizable"
+          ]
+        },
+        {
+          "description": "window:deny-set-shadow -> Denies the set_shadow command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-shadow"
+          ]
+        },
+        {
+          "description": "window:deny-set-size -> Denies the set_size command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-size"
+          ]
+        },
+        {
+          "description": "window:deny-set-skip-taskbar -> Denies the set_skip_taskbar command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-skip-taskbar"
+          ]
+        },
+        {
+          "description": "window:deny-set-title -> Denies the set_title command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-title"
+          ]
+        },
+        {
+          "description": "window:deny-set-visible-on-all-workspaces -> Denies the set_visible_on_all_workspaces command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-set-visible-on-all-workspaces"
+          ]
+        },
+        {
+          "description": "window:deny-show -> Denies the show command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-show"
+          ]
+        },
+        {
+          "description": "window:deny-start-dragging -> Denies the start_dragging command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-start-dragging"
+          ]
+        },
+        {
+          "description": "window:deny-start-resize-dragging -> Denies the start_resize_dragging command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-start-resize-dragging"
+          ]
+        },
+        {
+          "description": "window:deny-theme -> Denies the theme command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-theme"
+          ]
+        },
+        {
+          "description": "window:deny-title -> Denies the title command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-title"
+          ]
+        },
+        {
+          "description": "window:deny-toggle-maximize -> Denies the toggle_maximize command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-toggle-maximize"
+          ]
+        },
+        {
+          "description": "window:deny-unmaximize -> Denies the unmaximize command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-unmaximize"
+          ]
+        },
+        {
+          "description": "window:deny-unminimize -> Denies the unminimize command without any pre-configured scope.",
+          "type": "string",
+          "enum": [
+            "window:deny-unminimize"
+          ]
+        }
+      ]
+    },
+    "Value": {
+      "description": "All supported ACL values.",
+      "anyOf": [
+        {
+          "description": "Represents a null JSON value.",
+          "type": "null"
+        },
+        {
+          "description": "Represents a [`bool`].",
+          "type": "boolean"
+        },
+        {
+          "description": "Represents a valid ACL [`Number`].",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Number"
+            }
+          ]
+        },
+        {
+          "description": "Represents a [`String`].",
+          "type": "string"
+        },
+        {
+          "description": "Represents a list of other [`Value`]s.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Value"
+          }
+        },
+        {
+          "description": "Represents a map of [`String`] keys to [`Value`]s.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/Value"
+          }
+        }
+      ]
+    },
+    "Number": {
+      "description": "A valid ACL number.",
+      "anyOf": [
+        {
+          "description": "Represents an [`i64`].",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "Represents a [`f64`].",
+          "type": "number",
+          "format": "double"
+        }
+      ]
+    },
+    "Target": {
+      "description": "Platform target.",
+      "oneOf": [
+        {
+          "description": "MacOS.",
+          "type": "string",
+          "enum": [
+            "macOS"
+          ]
+        },
+        {
+          "description": "Windows.",
+          "type": "string",
+          "enum": [
+            "windows"
+          ]
+        },
+        {
+          "description": "Linux.",
+          "type": "string",
+          "enum": [
+            "linux"
+          ]
+        },
+        {
+          "description": "Android.",
+          "type": "string",
+          "enum": [
+            "android"
+          ]
+        },
+        {
+          "description": "iOS.",
+          "type": "string",
+          "enum": [
+            "iOS"
+          ]
+        }
+      ]
+    },
+    "ShellAllowedArg": {
+      "description": "A command argument allowed to be executed by the webview API.",
+      "anyOf": [
+        {
+          "description": "A non-configurable argument that is passed to the command in the order it was specified.",
+          "type": "string"
+        },
+        {
+          "description": "A variable that is set while calling the command from the webview API.",
+          "type": "object",
+          "required": [
+            "validator"
+          ],
+          "properties": {
+            "validator": {
+              "description": "[regex] validator to require passed values to conform to an expected input.\n\nThis will require the argument value passed to this variable to match the `validator` regex before it will be executed.\n\n[regex]: https://docs.rs/regex/latest/regex/#syntax",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "ShellAllowedArgs": {
+      "description": "A set of command arguments allowed to be executed by the webview API.\n\nA value of `true` will allow any arguments to be passed to the command. `false` will disable all arguments. A list of [`ShellAllowedArg`] will set those arguments as the only valid arguments to be passed to the attached command configuration.",
+      "anyOf": [
+        {
+          "description": "Use a simple boolean to allow all or disable all arguments to this command configuration.",
+          "type": "boolean"
+        },
+        {
+          "description": "A specific set of [`ShellAllowedArg`] that are valid to call for the command configuration.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ShellAllowedArg"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src-tauri/src/xap/device.rs
+++ b/src-tauri/src/xap/device.rs
@@ -342,10 +342,7 @@ impl XapDevice {
             board_ids,
             manufacturer,
             product_name,
-            hardware_id: format!(
-                "{}{}{}{}",
-                hardware_id[0], hardware_id[1], hardware_id[2], hardware_id[3]
-            ),
+            hardware_id: format_hardware_id(hardware_id),
             jump_to_bootloader_enabled: qmk_caps.contains(QmkCapabilitiesFlags::JumpToBootloader),
             eeprom_reset_enabled: qmk_caps.contains(QmkCapabilitiesFlags::ReinitializeEeprom),
         };
@@ -592,5 +589,26 @@ impl XapDevice {
 
     pub fn secure_status(&self) -> &XapSecureStatus {
         &self.state.secure_status
+    }
+}
+
+fn format_hardware_id(hardware_id: [u32; 4]) -> String {
+    hardware_id
+        .iter()
+        .map(|word| format!("0x{word:08X}"))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn hardware_id_uses_four_hex_words() {
+        assert_eq!(
+            format_hardware_id([0x00000001, 0x0000000A, 0x000000FF, 0x12345678]),
+            "0x00000001 0x0000000A 0x000000FF 0x12345678"
+        );
     }
 }

--- a/src/components/BasicKeyboardLayout.vue
+++ b/src/components/BasicKeyboardLayout.vue
@@ -256,7 +256,7 @@
                     v-for="code in group.codes"
                     :key="code.code"
                     :disabled="props.disabled || code.code === undefined"
-                    style="width: 4.5rem; height: 4.5rem"
+                    style="width: 3.25rem; height: 3.25rem"
                     class="keycode-button key-name-button rounded-lg p-2 border-2 ring-4 ring-inset shadow-md border-black ring-neutral-300 text-black"
                     @click="code.code !== undefined && emit('select', code.code)"
                 >

--- a/src/components/BasicKeyboardLayout.vue
+++ b/src/components/BasicKeyboardLayout.vue
@@ -6,7 +6,7 @@
     const props = defineProps<{ codes: KeyCode[]; disabled: boolean }>()
     const emit = defineEmits<{ select: [code: number] }>()
 
-    const UNIT = 3.5 // rem per keyboard unit
+    const UNIT = 4.75 // rem per keyboard unit — gives 4.5rem per 1u key (unit - 0.25rem gap)
 
     interface KeyPos {
         key: string
@@ -251,7 +251,7 @@
                     v-for="code in group.codes"
                     :key="code.code"
                     :disabled="props.disabled || code.code === undefined"
-                    style="width: 3.25rem; height: 3.25rem"
+                    style="width: 4.5rem; height: 4.5rem"
                     class="keycode-button key-name-button rounded-lg p-2 border-2 ring-4 ring-inset shadow-md border-black ring-neutral-300 text-black"
                     @click="code.code !== undefined && emit('select', code.code)"
                 >

--- a/src/components/BasicKeyboardLayout.vue
+++ b/src/components/BasicKeyboardLayout.vue
@@ -205,21 +205,13 @@
     )
 
     function posToStyle(pos: KeyPos): StyleValue {
-        const top = `${pos.y * UNIT}rem`
-        const left = `${pos.x * UNIT}rem`
-        const width = `${pos.w * UNIT - 0.25}rem`
-        const height = `${pos.h * UNIT - 0.25}rem`
         return {
-            '--key-top': top,
-            '--key-left': left,
-            '--key-width': width,
-            '--key-height': height,
             position: 'absolute',
-            top,
-            left,
-            width,
-            height,
-        } as Record<string, string>
+            top: `${pos.y * UNIT}rem`,
+            left: `${pos.x * UNIT}rem`,
+            width: `${pos.w * UNIT - 0.25}rem`,
+            height: `${pos.h * UNIT - 0.25}rem`,
+        }
     }
 </script>
 
@@ -232,7 +224,7 @@
             <button
                 v-for="{ pos, code } in layoutKeys"
                 :key="pos.key"
-                class="key-button key-name-button absolute rounded-lg p-1 border-2 ring-4 ring-inset shadow-md border-black ring-neutral-300 text-black"
+                class="key-name-button absolute rounded-lg p-1 border-2 ring-4 ring-inset shadow-md border-black ring-neutral-300 text-black"
                 :class="{ 'opacity-30 cursor-default': code === null }"
                 :disabled="props.disabled || code === null || code.code === undefined"
                 :style="posToStyle(pos)"
@@ -241,6 +233,9 @@
                 <span class="text-xs leading-tight">{{
                     code?.label ?? code?.key ?? pos.key
                 }}</span>
+                <q-tooltip v-if="props.disabled" icon="block" class="bg-red">
+                    Device is locked
+                </q-tooltip>
             </button>
         </div>
         <div
@@ -285,12 +280,6 @@
     max-width: 100%;
 }
 
-.key-button:hover {
-    width: calc(var(--key-width) + 0.5rem) !important;
-    height: calc(var(--key-height) + 0.5rem) !important;
-    top: calc(var(--key-top) - 0.25rem) !important;
-    left: calc(var(--key-left) - 0.25rem) !important;
-}
 
 .keycode-button:hover {
     background-color: rgba(0, 0, 0, 0.05);

--- a/src/components/BasicKeyboardLayout.vue
+++ b/src/components/BasicKeyboardLayout.vue
@@ -233,7 +233,7 @@
                 <span class="text-xs leading-tight">{{
                     code?.label ?? code?.key ?? pos.key
                 }}</span>
-                <q-tooltip v-if="props.disabled" icon="block" class="bg-red">
+                <q-tooltip v-if="props.disabled" icon="block" class="bg-red" style="white-space: nowrap">
                     Device is locked
                 </q-tooltip>
             </button>

--- a/src/components/BasicKeyboardLayout.vue
+++ b/src/components/BasicKeyboardLayout.vue
@@ -1,0 +1,299 @@
+<script setup lang="ts">
+    import { computed } from 'vue'
+    import type { StyleValue } from 'vue'
+    import type { KeyCode } from '@generated/xap'
+
+    const props = defineProps<{ codes: KeyCode[]; disabled: boolean }>()
+    const emit = defineEmits<{ select: [code: number] }>()
+
+    const UNIT = 3.5 // rem per keyboard unit
+
+    interface KeyPos {
+        key: string
+        x: number
+        y: number
+        w: number
+        h: number
+    }
+
+    const ANSI_LAYOUT: KeyPos[] = [
+        // Function row (y=0)
+        { key: 'KC_ESCAPE', x: 0, y: 0, w: 1, h: 1 },
+        { key: 'KC_F1', x: 2, y: 0, w: 1, h: 1 },
+        { key: 'KC_F2', x: 3, y: 0, w: 1, h: 1 },
+        { key: 'KC_F3', x: 4, y: 0, w: 1, h: 1 },
+        { key: 'KC_F4', x: 5, y: 0, w: 1, h: 1 },
+        { key: 'KC_F5', x: 6.5, y: 0, w: 1, h: 1 },
+        { key: 'KC_F6', x: 7.5, y: 0, w: 1, h: 1 },
+        { key: 'KC_F7', x: 8.5, y: 0, w: 1, h: 1 },
+        { key: 'KC_F8', x: 9.5, y: 0, w: 1, h: 1 },
+        { key: 'KC_F9', x: 11, y: 0, w: 1, h: 1 },
+        { key: 'KC_F10', x: 12, y: 0, w: 1, h: 1 },
+        { key: 'KC_F11', x: 13, y: 0, w: 1, h: 1 },
+        { key: 'KC_F12', x: 14, y: 0, w: 1, h: 1 },
+        { key: 'KC_PRINT_SCREEN', x: 15.5, y: 0, w: 1, h: 1 },
+        { key: 'KC_SCROLL_LOCK', x: 16.5, y: 0, w: 1, h: 1 },
+        { key: 'KC_PAUSE', x: 17.5, y: 0, w: 1, h: 1 },
+
+        // Number row (y=1.5)
+        { key: 'KC_GRAVE', x: 0, y: 1.5, w: 1, h: 1 },
+        { key: 'KC_1', x: 1, y: 1.5, w: 1, h: 1 },
+        { key: 'KC_2', x: 2, y: 1.5, w: 1, h: 1 },
+        { key: 'KC_3', x: 3, y: 1.5, w: 1, h: 1 },
+        { key: 'KC_4', x: 4, y: 1.5, w: 1, h: 1 },
+        { key: 'KC_5', x: 5, y: 1.5, w: 1, h: 1 },
+        { key: 'KC_6', x: 6, y: 1.5, w: 1, h: 1 },
+        { key: 'KC_7', x: 7, y: 1.5, w: 1, h: 1 },
+        { key: 'KC_8', x: 8, y: 1.5, w: 1, h: 1 },
+        { key: 'KC_9', x: 9, y: 1.5, w: 1, h: 1 },
+        { key: 'KC_0', x: 10, y: 1.5, w: 1, h: 1 },
+        { key: 'KC_MINUS', x: 11, y: 1.5, w: 1, h: 1 },
+        { key: 'KC_EQUAL', x: 12, y: 1.5, w: 1, h: 1 },
+        { key: 'KC_BACKSPACE', x: 13, y: 1.5, w: 2, h: 1 },
+
+        // QWERTY row (y=2.5)
+        { key: 'KC_TAB', x: 0, y: 2.5, w: 1.5, h: 1 },
+        { key: 'KC_Q', x: 1.5, y: 2.5, w: 1, h: 1 },
+        { key: 'KC_W', x: 2.5, y: 2.5, w: 1, h: 1 },
+        { key: 'KC_E', x: 3.5, y: 2.5, w: 1, h: 1 },
+        { key: 'KC_R', x: 4.5, y: 2.5, w: 1, h: 1 },
+        { key: 'KC_T', x: 5.5, y: 2.5, w: 1, h: 1 },
+        { key: 'KC_Y', x: 6.5, y: 2.5, w: 1, h: 1 },
+        { key: 'KC_U', x: 7.5, y: 2.5, w: 1, h: 1 },
+        { key: 'KC_I', x: 8.5, y: 2.5, w: 1, h: 1 },
+        { key: 'KC_O', x: 9.5, y: 2.5, w: 1, h: 1 },
+        { key: 'KC_P', x: 10.5, y: 2.5, w: 1, h: 1 },
+        { key: 'KC_LEFT_BRACKET', x: 11.5, y: 2.5, w: 1, h: 1 },
+        { key: 'KC_RIGHT_BRACKET', x: 12.5, y: 2.5, w: 1, h: 1 },
+        { key: 'KC_BACKSLASH', x: 13.5, y: 2.5, w: 1.5, h: 1 },
+
+        // Caps row (y=3.5)
+        { key: 'KC_CAPS_LOCK', x: 0, y: 3.5, w: 1.75, h: 1 },
+        { key: 'KC_A', x: 1.75, y: 3.5, w: 1, h: 1 },
+        { key: 'KC_S', x: 2.75, y: 3.5, w: 1, h: 1 },
+        { key: 'KC_D', x: 3.75, y: 3.5, w: 1, h: 1 },
+        { key: 'KC_F', x: 4.75, y: 3.5, w: 1, h: 1 },
+        { key: 'KC_G', x: 5.75, y: 3.5, w: 1, h: 1 },
+        { key: 'KC_H', x: 6.75, y: 3.5, w: 1, h: 1 },
+        { key: 'KC_J', x: 7.75, y: 3.5, w: 1, h: 1 },
+        { key: 'KC_K', x: 8.75, y: 3.5, w: 1, h: 1 },
+        { key: 'KC_L', x: 9.75, y: 3.5, w: 1, h: 1 },
+        { key: 'KC_SEMICOLON', x: 10.75, y: 3.5, w: 1, h: 1 },
+        { key: 'KC_QUOTE', x: 11.75, y: 3.5, w: 1, h: 1 },
+        { key: 'KC_ENTER', x: 12.75, y: 3.5, w: 2.25, h: 1 },
+
+        // Shift row (y=4.5)
+        { key: 'KC_LEFT_SHIFT', x: 0, y: 4.5, w: 2.25, h: 1 },
+        { key: 'KC_Z', x: 2.25, y: 4.5, w: 1, h: 1 },
+        { key: 'KC_X', x: 3.25, y: 4.5, w: 1, h: 1 },
+        { key: 'KC_C', x: 4.25, y: 4.5, w: 1, h: 1 },
+        { key: 'KC_V', x: 5.25, y: 4.5, w: 1, h: 1 },
+        { key: 'KC_B', x: 6.25, y: 4.5, w: 1, h: 1 },
+        { key: 'KC_N', x: 7.25, y: 4.5, w: 1, h: 1 },
+        { key: 'KC_M', x: 8.25, y: 4.5, w: 1, h: 1 },
+        { key: 'KC_COMMA', x: 9.25, y: 4.5, w: 1, h: 1 },
+        { key: 'KC_DOT', x: 10.25, y: 4.5, w: 1, h: 1 },
+        { key: 'KC_SLASH', x: 11.25, y: 4.5, w: 1, h: 1 },
+        { key: 'KC_RIGHT_SHIFT', x: 12.25, y: 4.5, w: 2.75, h: 1 },
+
+        // Bottom row (y=5.5)
+        { key: 'KC_LEFT_CTRL', x: 0, y: 5.5, w: 1.25, h: 1 },
+        { key: 'KC_LEFT_GUI', x: 1.25, y: 5.5, w: 1.25, h: 1 },
+        { key: 'KC_LEFT_ALT', x: 2.5, y: 5.5, w: 1.25, h: 1 },
+        { key: 'KC_SPACE', x: 3.75, y: 5.5, w: 6.25, h: 1 },
+        { key: 'KC_RIGHT_ALT', x: 10, y: 5.5, w: 1.25, h: 1 },
+        { key: 'KC_RIGHT_GUI', x: 11.25, y: 5.5, w: 1.25, h: 1 },
+        { key: 'KC_APPLICATION', x: 12.5, y: 5.5, w: 1.25, h: 1 },
+        { key: 'KC_RIGHT_CTRL', x: 13.75, y: 5.5, w: 1.25, h: 1 },
+
+        // Edit cluster (x offset = 15.5)
+        { key: 'KC_INSERT', x: 15.5, y: 1.5, w: 1, h: 1 },
+        { key: 'KC_HOME', x: 16.5, y: 1.5, w: 1, h: 1 },
+        { key: 'KC_PAGE_UP', x: 17.5, y: 1.5, w: 1, h: 1 },
+        { key: 'KC_DELETE', x: 15.5, y: 2.5, w: 1, h: 1 },
+        { key: 'KC_END', x: 16.5, y: 2.5, w: 1, h: 1 },
+        { key: 'KC_PAGE_DOWN', x: 17.5, y: 2.5, w: 1, h: 1 },
+
+        // Arrow keys
+        { key: 'KC_UP', x: 16.5, y: 4.5, w: 1, h: 1 },
+        { key: 'KC_LEFT', x: 15.5, y: 5.5, w: 1, h: 1 },
+        { key: 'KC_DOWN', x: 16.5, y: 5.5, w: 1, h: 1 },
+        { key: 'KC_RIGHT', x: 17.5, y: 5.5, w: 1, h: 1 },
+
+        // Numpad (x offset = 19)
+        { key: 'KC_NUM_LOCK', x: 19, y: 1.5, w: 1, h: 1 },
+        { key: 'KC_KP_SLASH', x: 20, y: 1.5, w: 1, h: 1 },
+        { key: 'KC_KP_ASTERISK', x: 21, y: 1.5, w: 1, h: 1 },
+        { key: 'KC_KP_MINUS', x: 22, y: 1.5, w: 1, h: 1 },
+        { key: 'KC_KP_7', x: 19, y: 2.5, w: 1, h: 1 },
+        { key: 'KC_KP_8', x: 20, y: 2.5, w: 1, h: 1 },
+        { key: 'KC_KP_9', x: 21, y: 2.5, w: 1, h: 1 },
+        { key: 'KC_KP_PLUS', x: 22, y: 2.5, w: 1, h: 2 },
+        { key: 'KC_KP_4', x: 19, y: 3.5, w: 1, h: 1 },
+        { key: 'KC_KP_5', x: 20, y: 3.5, w: 1, h: 1 },
+        { key: 'KC_KP_6', x: 21, y: 3.5, w: 1, h: 1 },
+        { key: 'KC_KP_1', x: 19, y: 4.5, w: 1, h: 1 },
+        { key: 'KC_KP_2', x: 20, y: 4.5, w: 1, h: 1 },
+        { key: 'KC_KP_3', x: 21, y: 4.5, w: 1, h: 1 },
+        { key: 'KC_KP_ENTER', x: 22, y: 4.5, w: 1, h: 2 },
+        { key: 'KC_KP_0', x: 19, y: 5.5, w: 2, h: 1 },
+        { key: 'KC_KP_DOT', x: 21, y: 5.5, w: 1, h: 1 },
+    ]
+
+    const OVERFLOW_GROUPS = [
+        {
+            label: 'Extended F-Keys',
+            keys: [
+                'KC_F13', 'KC_F14', 'KC_F15', 'KC_F16', 'KC_F17', 'KC_F18',
+                'KC_F19', 'KC_F20', 'KC_F21', 'KC_F22', 'KC_F23', 'KC_F24',
+            ],
+        },
+        {
+            label: 'Non-US',
+            keys: ['KC_NONUS_HASH', 'KC_NONUS_BACKSLASH'],
+        },
+        {
+            label: 'Locking Keys',
+            keys: ['KC_LOCKING_CAPS_LOCK', 'KC_LOCKING_NUM_LOCK', 'KC_LOCKING_SCROLL_LOCK'],
+        },
+        {
+            label: 'Numpad Extras',
+            keys: ['KC_KP_EQUAL', 'KC_KP_EQUAL_AS400', 'KC_KP_COMMA'],
+        },
+        {
+            label: 'Commands',
+            keys: [
+                'KC_KB_POWER', 'KC_EXECUTE', 'KC_HELP', 'KC_MENU', 'KC_SELECT', 'KC_STOP',
+                'KC_AGAIN', 'KC_UNDO', 'KC_CUT', 'KC_COPY', 'KC_PASTE', 'KC_FIND',
+                'KC_KB_MUTE', 'KC_KB_VOLUME_UP', 'KC_KB_VOLUME_DOWN',
+                'KC_ALTERNATE_ERASE', 'KC_SYSTEM_REQUEST', 'KC_CANCEL', 'KC_CLEAR',
+                'KC_PRIOR', 'KC_RETURN', 'KC_SEPARATOR', 'KC_OUT', 'KC_OPER',
+                'KC_CLEAR_AGAIN', 'KC_CRSEL', 'KC_EXSEL',
+            ],
+        },
+        {
+            label: 'International',
+            keys: [
+                'KC_INTERNATIONAL_1', 'KC_INTERNATIONAL_2', 'KC_INTERNATIONAL_3',
+                'KC_INTERNATIONAL_4', 'KC_INTERNATIONAL_5', 'KC_INTERNATIONAL_6',
+                'KC_INTERNATIONAL_7', 'KC_INTERNATIONAL_8', 'KC_INTERNATIONAL_9',
+                'KC_LANGUAGE_1', 'KC_LANGUAGE_2', 'KC_LANGUAGE_3', 'KC_LANGUAGE_4',
+                'KC_LANGUAGE_5', 'KC_LANGUAGE_6', 'KC_LANGUAGE_7', 'KC_LANGUAGE_8',
+                'KC_LANGUAGE_9',
+            ],
+        },
+    ]
+
+    const codeMap = computed(() => {
+        const m = new Map<string, KeyCode>()
+        for (const c of props.codes) m.set(c.key, c)
+        return m
+    })
+
+    const layoutKeys = computed(() =>
+        ANSI_LAYOUT.map((pos) => ({ pos, code: codeMap.value.get(pos.key) ?? null })),
+    )
+
+    const overflowGroups = computed(() =>
+        OVERFLOW_GROUPS.map((g) => ({
+            label: g.label,
+            codes: g.keys.flatMap((k) => {
+                const c = codeMap.value.get(k)
+                return c ? [c] : []
+            }),
+        })).filter((g) => g.codes.length > 0),
+    )
+
+    function posToStyle(pos: KeyPos): StyleValue {
+        const top = `${pos.y * UNIT}rem`
+        const left = `${pos.x * UNIT}rem`
+        const width = `${pos.w * UNIT - 0.25}rem`
+        const height = `${pos.h * UNIT - 0.25}rem`
+        return {
+            '--key-top': top,
+            '--key-left': left,
+            '--key-width': width,
+            '--key-height': height,
+            position: 'absolute',
+            top,
+            left,
+            width,
+            height,
+        } as Record<string, string>
+    }
+</script>
+
+<template>
+    <div style="overflow-x: auto">
+        <div
+            class="relative"
+            :style="{ width: `${23 * UNIT}rem`, height: `${6.5 * UNIT}rem` }"
+        >
+            <button
+                v-for="{ pos, code } in layoutKeys"
+                :key="pos.key"
+                class="key-button key-name-button absolute rounded-lg p-1 border-2 ring-4 ring-inset shadow-md border-black ring-neutral-300 text-black"
+                :class="{ 'opacity-30 cursor-default': code === null }"
+                :disabled="props.disabled || code === null || code.code === undefined"
+                :style="posToStyle(pos)"
+                @click="code?.code !== undefined && emit('select', code.code)"
+            >
+                <span class="text-xs leading-tight">{{
+                    code?.label ?? code?.key ?? pos.key
+                }}</span>
+            </button>
+        </div>
+        <div
+            v-for="group in overflowGroups"
+            :key="group.label"
+            class="mt-4"
+        >
+            <div class="text-xs font-semibold text-gray-500 mb-1 uppercase tracking-wide">
+                {{ group.label }}
+            </div>
+            <div class="flex flex-wrap gap-2">
+                <button
+                    v-for="code in group.codes"
+                    :key="code.code"
+                    :disabled="props.disabled || code.code === undefined"
+                    style="width: 4.5rem; height: 4.5rem"
+                    class="keycode-button key-name-button rounded-lg p-2 border-2 ring-4 ring-inset shadow-md border-black ring-neutral-300 text-black"
+                    @click="code.code !== undefined && emit('select', code.code)"
+                >
+                    <span>{{ code.label ?? code.key }}</span>
+                </button>
+            </div>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+.key-name-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    text-align: center;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    line-height: 1.1;
+}
+
+.key-name-button span {
+    display: block;
+    max-width: 100%;
+}
+
+.key-button:hover {
+    width: calc(var(--key-width) + 0.5rem) !important;
+    height: calc(var(--key-height) + 0.5rem) !important;
+    top: calc(var(--key-top) - 0.25rem) !important;
+    left: calc(var(--key-left) - 0.25rem) !important;
+}
+
+.keycode-button:hover {
+    background-color: rgba(0, 0, 0, 0.05);
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+}
+</style>

--- a/src/pages/DeviceInfoView.vue
+++ b/src/pages/DeviceInfoView.vue
@@ -4,6 +4,7 @@
     import { useXapDeviceStore } from '@/utils/deviceStore'
     import { XapSecureStatus, XapDeviceState } from '@generated/xap'
     import { commands } from '@/utils/commands'
+    import { formatBcdVersion } from '@/utils/format'
     import type { Ref } from 'vue'
 
     const store = useXapDeviceStore()
@@ -65,14 +66,14 @@
             <q-field filled label="XAP Version" stack-label>
                 <template #control>
                     <div class="self-center full-width no-outline" tabindex="0">
-                        {{ device?.info?.xap.version }}
+                        {{ formatBcdVersion(device?.info?.xap.version) }}
                     </div>
                 </template>
             </q-field>
             <q-field filled label="QMK Version" stack-label>
                 <template #control>
                     <div class="self-center full-width no-outline" tabindex="0">
-                        {{ device?.info?.qmk.version }}
+                        {{ formatBcdVersion(device?.info?.qmk.version) }}
                     </div>
                 </template>
             </q-field>

--- a/src/pages/KeymapView.vue
+++ b/src/pages/KeymapView.vue
@@ -50,8 +50,9 @@
         return {
             top: `${layout.y * 5}rem`,
             left: `${layout.x * 5}rem`,
-            width: `${layout.w! * 4.5}rem`,
-            height: `${layout.h! * 4.5}rem`,
+            width: `${layout.w! * 5 - 0.5}rem`,
+            height: `${layout.h! * 5 - 0.5}rem`,
+            margin: `0.25rem`,
         }
     }
 

--- a/src/pages/KeymapView.vue
+++ b/src/pages/KeymapView.vue
@@ -139,7 +139,7 @@
             <!--   Keymap   -->
             <q-tab-panels v-model="layerTab">
                 <q-tab-panel
-                    :style="{ height: `${Math.max(keymap?.size.y ?? 2, 2) * 3}rem` }"
+                    :style="{ height: `${Math.max(keymap?.size.y ?? 2, 2) * 6}rem` }"
                     v-for="(layer, layer_idx) in keymap?.keys"
                     :name="layer_idx"
                 >

--- a/src/pages/KeymapView.vue
+++ b/src/pages/KeymapView.vue
@@ -227,7 +227,7 @@
 }
 
 .keycode-button:hover {
-    width: 5rem !important;
-    height: 5rem !important;
+    background-color: rgba(0, 0, 0, 0.05);
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
 }
 </style>

--- a/src/pages/KeymapView.vue
+++ b/src/pages/KeymapView.vue
@@ -13,6 +13,7 @@
     } from '@generated/xap'
     import { commands } from '@/utils/commands'
     import { notifyError } from '@/utils/utils'
+    import BasicKeyboardLayout from '@/components/BasicKeyboardLayout.vue'
 
     const store = useXapDeviceStore()
     const { device } = storeToRefs(store) as { device: Ref<XapDeviceState | null> }
@@ -195,23 +196,31 @@
                     :label="category.name"
                     class="row"
                 >
-                    <button
-                        v-for="code in category.codes"
-                        :key="code.code"
+                    <BasicKeyboardLayout
+                        v-if="category.name === 'basic'"
+                        :codes="category.codes"
                         :disabled="device?.secure_status != 'Unlocked'"
-                        style="width: 4.5rem; height: 4.5rem"
-                        class="keycode-button key-name-button mr-2 mb-2 rounded-lg p-2 text-black border-2 ring-4 ring-inset shadow-md border-black ring-neutral-300"
-                        @click="remapKey(code.code!)"
-                    >
-                        <span>{{ code.label ?? code.key }}</span>
-                        <q-tooltip
-                            v-if="device?.secure_status != 'Unlocked'"
-                            icon="block"
-                            class="bg-red"
+                        @select="remapKey"
+                    />
+                    <template v-else>
+                        <button
+                            v-for="code in category.codes"
+                            :key="code.code"
+                            :disabled="device?.secure_status != 'Unlocked'"
+                            style="width: 4.5rem; height: 4.5rem"
+                            class="keycode-button key-name-button mr-2 mb-2 rounded-lg p-2 text-black border-2 ring-4 ring-inset shadow-md border-black ring-neutral-300"
+                            @click="remapKey(code.code!)"
                         >
-                            Device is locked
-                        </q-tooltip>
-                    </button>
+                            <span>{{ code.label ?? code.key }}</span>
+                            <q-tooltip
+                                v-if="device?.secure_status != 'Unlocked'"
+                                icon="block"
+                                class="bg-red"
+                            >
+                                Device is locked
+                            </q-tooltip>
+                        </button>
+                    </template>
                 </q-tab-panel>
             </q-tab-panels>
         </div>

--- a/src/pages/KeymapView.vue
+++ b/src/pages/KeymapView.vue
@@ -157,7 +157,7 @@
                         <template v-for="row in layer">
                             <button
                                 v-for="col in row.filter((col) => col != null)"
-                                class="key-button truncate rounded-lg p-2 absolute align-middle text-black border-2 ring-4 ring-inset shadow-md"
+                                class="key-button key-name-button rounded-lg p-2 absolute align-middle text-black border-2 ring-4 ring-inset shadow-md"
                                 :class="applyKeySelection(col!.key.position)"
                                 :style="applyLayout(col!.layout)"
                                 @click="() => (selectedKey = col!.key.position)"
@@ -200,7 +200,7 @@
                         :key="code.code"
                         :disabled="device?.secure_status != 'Unlocked'"
                         style="width: 4.5rem; height: 4.5rem"
-                        class="keycode-button mr-2 mb-2 truncate rounded-lg p-2 text-black border-2 ring-4 ring-inset shadow-md border-black ring-neutral-300"
+                        class="keycode-button key-name-button mr-2 mb-2 rounded-lg p-2 text-black border-2 ring-4 ring-inset shadow-md border-black ring-neutral-300"
                         @click="remapKey(code.code!)"
                     >
                         <span>{{ code.label ?? code.key }}</span>
@@ -219,6 +219,23 @@
 </template>
 
 <style scoped>
+.key-name-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    text-align: center;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    line-height: 1.1;
+}
+
+.key-name-button span {
+    display: block;
+    max-width: 100%;
+}
+
 .key-button:hover {
     width: calc(var(--key-width) + 0.5rem) !important;
     height: calc(var(--key-height) + 0.5rem) !important;

--- a/src/pages/KeymapView.vue
+++ b/src/pages/KeymapView.vue
@@ -216,6 +216,7 @@
                                 v-if="device?.secure_status != 'Unlocked'"
                                 icon="block"
                                 class="bg-red"
+                                style="white-space: nowrap"
                             >
                                 Device is locked
                             </q-tooltip>

--- a/src/pages/KeymapView.vue
+++ b/src/pages/KeymapView.vue
@@ -207,7 +207,7 @@
                             v-for="code in category.codes"
                             :key="code.code"
                             :disabled="device?.secure_status != 'Unlocked'"
-                            style="width: 4.5rem; height: 4.5rem"
+                            style="width: 3.25rem; height: 3.25rem"
                             class="keycode-button key-name-button mr-2 mb-2 rounded-lg p-2 text-black border-2 ring-4 ring-inset shadow-md border-black ring-neutral-300"
                             @click="remapKey(code.code!)"
                         >

--- a/src/pages/KeymapView.vue
+++ b/src/pages/KeymapView.vue
@@ -47,18 +47,27 @@
     }
 
     function applyLayout(layout: LayoutEntry): StyleValue {
+        const top = `${layout.y * 5}rem`
+        const left = `${layout.x * 5}rem`
+        const width = `${layout.w! * 5 - 0.5}rem`
+        const height = `${layout.h! * 5 - 0.5}rem`
+
         return {
-            top: `${layout.y * 5}rem`,
-            left: `${layout.x * 5}rem`,
-            width: `${layout.w! * 5 - 0.5}rem`,
-            height: `${layout.h! * 5 - 0.5}rem`,
+            '--key-top': top,
+            '--key-left': left,
+            '--key-width': width,
+            '--key-height': height,
+            top: top,
+            left: left,
+            width: width,
+            height: height,
             margin: `0.25rem`,
         }
     }
 
     function applyKeySelection(position: Point3D): string {
         return selectedKey.value?.x == position.x && selectedKey.value?.y == position.y && selectedKey.value?.z == position.z
-            ? 'border-amber-500 ring-amber-300 scale-110'
+            ? 'border-amber-500 ring-amber-300'
             : 'border-black ring-neutral-300'
     }
 
@@ -148,7 +157,7 @@
                         <template v-for="row in layer">
                             <button
                                 v-for="col in row.filter((col) => col != null)"
-                                class="hover:scale-110 truncate rounded-lg p-2 absolute align-middle text-black border-2 ring-4 ring-inset shadow-md"
+                                class="key-button truncate rounded-lg p-2 absolute align-middle text-black border-2 ring-4 ring-inset shadow-md"
                                 :class="applyKeySelection(col!.key.position)"
                                 :style="applyLayout(col!.layout)"
                                 @click="() => (selectedKey = col!.key.position)"
@@ -191,7 +200,7 @@
                         :key="code.code"
                         :disabled="device?.secure_status != 'Unlocked'"
                         style="width: 4.5rem; height: 4.5rem"
-                        class="mr-2 mb-2 hover:scale-110 truncate rounded-lg p-2 text-black border-2 ring-4 ring-inset shadow-md border-black ring-neutral-300"
+                        class="keycode-button mr-2 mb-2 truncate rounded-lg p-2 text-black border-2 ring-4 ring-inset shadow-md border-black ring-neutral-300"
                         @click="remapKey(code.code!)"
                     >
                         <span>{{ code.label ?? code.key }}</span>
@@ -208,3 +217,17 @@
         </div>
     </q-page>
 </template>
+
+<style scoped>
+.key-button:hover {
+    width: calc(var(--key-width) + 0.5rem) !important;
+    height: calc(var(--key-height) + 0.5rem) !important;
+    top: calc(var(--key-top) - 0.25rem) !important;
+    left: calc(var(--key-left) - 0.25rem) !important;
+}
+
+.keycode-button:hover {
+    width: 5rem !important;
+    height: 5rem !important;
+}
+</style>

--- a/src/pages/KeymapView.vue
+++ b/src/pages/KeymapView.vue
@@ -207,7 +207,7 @@
                             v-for="code in category.codes"
                             :key="code.code"
                             :disabled="device?.secure_status != 'Unlocked'"
-                            style="width: 3.25rem; height: 3.25rem"
+                            style="width: 4.5rem; height: 4.5rem"
                             class="keycode-button key-name-button mr-2 mb-2 rounded-lg p-2 text-black border-2 ring-4 ring-inset shadow-md border-black ring-neutral-300"
                             @click="remapKey(code.code!)"
                         >

--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatBcdVersion } from './format'
+
+describe('formatBcdVersion', () => {
+    it('formats BCD-encoded XAP and QMK versions as dotted versions', () => {
+        expect(formatBcdVersion(0x03020115)).toBe('3.2.115')
+        expect(formatBcdVersion(0x00030000)).toBe('0.3.0')
+        expect(formatBcdVersion(0x00000001)).toBe('0.0.1')
+    })
+
+    it('formats decimal-string versions returned by the backend', () => {
+        expect(formatBcdVersion(String(0x03020115))).toBe('3.2.115')
+    })
+
+    it('falls back to hex for invalid BCD values', () => {
+        expect(formatBcdVersion(0x03020a15)).toBe('0x03020A15')
+    })
+})

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,19 @@
+export function formatBcdVersion(version: number | string | null | undefined): string {
+    if (version == null) {
+        return ''
+    }
+
+    const raw = typeof version === 'string' ? Number(version) : version
+
+    if (!Number.isFinite(raw) || raw < 0) {
+        return String(version)
+    }
+
+    const hex = Math.trunc(raw).toString(16).padStart(8, '0').slice(-8).toUpperCase()
+
+    if (!/^[0-9]{8}$/.test(hex)) {
+        return `0x${hex}`
+    }
+
+    return `${Number(hex.slice(0, 2))}.${Number(hex.slice(2, 4))}.${Number(hex.slice(4, 8))}`
+}

--- a/xap-specs/src/constants/keycode.rs
+++ b/xap-specs/src/constants/keycode.rs
@@ -34,11 +34,13 @@ pub struct XapKeyCodeCategory {
 
 impl KeyCode {
     pub fn new_custom(code: u16) -> Self {
+        let keycode = format!("0x{code:04X}");
+
         Self {
             code,
-            key: format!("USER-CUSTOM-{code}"),
+            key: keycode.clone(),
             group: Some("USER-CUSTOM".to_owned()),
-            label: Some(format!("{code}")),
+            label: Some(keycode),
             aliases: vec![],
         }
     }
@@ -198,6 +200,20 @@ mod test {
                 group: Some("basic".to_owned()),
                 key: "KC_B".to_owned(),
                 label: Some("B".to_owned()),
+                aliases: vec![]
+            }
+        );
+    }
+
+    #[test]
+    pub fn custom_keycodes_use_hex_display_names() {
+        assert_eq!(
+            KeyCode::new_custom(0x000A),
+            KeyCode {
+                code: 0x000A,
+                group: Some("USER-CUSTOM".to_owned()),
+                key: "0x000A".to_owned(),
+                label: Some("0x000A".to_owned()),
                 aliases: vec![]
             }
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -424,6 +424,35 @@
   resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.10.0.tgz#548f6de556857c8bb73bbee70c35dc82a2e74d63"
   integrity sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==
 
+"@eslint/eslintrc@^1.0.5":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.4.1.tgz#af58772019a2d271b7e2d4c23ff4ddcba3ccfb3e"
+  integrity sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==
+  dependencies:
+    ajv "^6.12.4"
+    debug "^4.3.2"
+    espree "^9.4.0"
+    globals "^13.19.0"
+    ignore "^5.2.0"
+    import-fresh "^3.2.1"
+    js-yaml "^4.1.0"
+    minimatch "^3.1.2"
+    strip-json-comments "^3.1.1"
+
+"@humanwhocodes/config-array@^0.9.2":
+  version "0.9.5"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.5.tgz#2cbaf9a89460da24b5ca6531b8bbfc23e1df50c7"
+  integrity sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==
+  dependencies:
+    "@humanwhocodes/object-schema" "^1.2.1"
+    debug "^4.1.1"
+    minimatch "^3.0.4"
+
+"@humanwhocodes/object-schema@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
+  integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -1055,6 +1084,21 @@ acorn@^8.11.3, acorn@^8.9.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
   integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
 
+ajv@^6.10.0, ajv@^6.12.4:
+  version "6.12.6"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
+  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ansi-colors@^4.1.1:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.3.tgz#37611340eb2243e70cc604cad35d63270d48781b"
+  integrity sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -1072,7 +1116,7 @@ ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.0.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
@@ -1106,6 +1150,11 @@ arg@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.2.tgz#c81433cc427c92c4dcf4865142dbca6f15acd59c"
   integrity sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==
+
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 array-union@^2.1.0:
   version "2.1.0"
@@ -1144,6 +1193,14 @@ boolbase@^1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
+brace-expansion@^1.1.7:
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.12.tgz#ab9b454466e5a8cc3a187beaad580412a9c5b843"
+  integrity sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==
+  dependencies:
+    balanced-match "^1.0.0"
+    concat-map "0.0.1"
+
 brace-expansion@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
@@ -1172,6 +1229,11 @@ cac@^6.7.14:
   version "6.7.14"
   resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
   integrity sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
+
+callsites@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
+  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
 camelcase-css@^2.0.1:
   version "2.0.1"
@@ -1209,6 +1271,14 @@ chalk@^2.4.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+chalk@^4.0.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
 
 check-error@^1.0.3:
   version "1.0.3"
@@ -1271,6 +1341,11 @@ computeds@^0.0.1:
   resolved "https://registry.yarnpkg.com/computeds/-/computeds-0.0.1.tgz#215b08a4ba3e08a11ff6eee5d6d8d7166a97ce2e"
   integrity sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==
 
+concat-map@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
+  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+
 confbox@^0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/confbox/-/confbox-0.1.7.tgz#ccfc0a2bcae36a84838e83a3b7f770fb17d6c579"
@@ -1285,6 +1360,15 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
+cross-spawn@^7.0.2:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
@@ -1312,12 +1396,24 @@ debug@^4.1.0, debug@^4.3.1, debug@^4.3.4:
   dependencies:
     ms "2.1.2"
 
+debug@^4.1.1, debug@^4.3.2:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
 deep-eql@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-4.1.3.tgz#7c7775513092f7df98d8df9996dd085eb668cc6d"
   integrity sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==
   dependencies:
     type-detect "^4.0.0"
+
+deep-is@^0.1.3:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
+  integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
 didyoumean@^1.2.2:
   version "1.2.2"
@@ -1340,6 +1436,13 @@ dlv@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
   integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
+
+doctrine@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
+  dependencies:
+    esutils "^2.0.2"
 
 eastasianwidth@^0.2.0:
   version "0.2.0"
@@ -1368,6 +1471,14 @@ enhanced-resolve@^5.15.0:
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
+
+enquirer@^2.3.5:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.4.1.tgz#93334b3fbd74fc7097b224ab4a8fb7e40bf4ae56"
+  integrity sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==
+  dependencies:
+    ansi-colors "^4.1.1"
+    strip-ansi "^6.0.1"
 
 entities@^4.5.0:
   version "4.5.0"
@@ -1412,6 +1523,11 @@ escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
+
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 escape-string-regexp@^5.0.0:
   version "5.0.0"
@@ -1482,7 +1598,7 @@ eslint-plugin-vue@9.26.0:
     vue-eslint-parser "^9.4.2"
     xml-name-validator "^4.0.0"
 
-eslint-scope@^7.1.1:
+eslint-scope@^7.1.0, eslint-scope@^7.1.1:
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.2.2.tgz#deb4f92563390f32006894af62a22dba1c46423f"
   integrity sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==
@@ -1490,12 +1606,68 @@ eslint-scope@^7.1.1:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
 
-eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
+eslint-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
+  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
+  dependencies:
+    eslint-visitor-keys "^2.0.0"
+
+eslint-visitor-keys@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
+  integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
+
+eslint-visitor-keys@^3.1.0, eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
-espree@^9.3.1:
+eslint@~8.6.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.6.0.tgz#4318c6a31c5584838c1a2e940c478190f58d558e"
+  integrity sha512-UvxdOJ7mXFlw7iuHZA4jmzPaUqIw54mZrv+XPYKNbKdLR0et4rf60lIZUU9kiNtnzzMzGWxMV+tQ7uG7JG8DPw==
+  dependencies:
+    "@eslint/eslintrc" "^1.0.5"
+    "@humanwhocodes/config-array" "^0.9.2"
+    ajv "^6.10.0"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
+    debug "^4.3.2"
+    doctrine "^3.0.0"
+    enquirer "^2.3.5"
+    escape-string-regexp "^4.0.0"
+    eslint-scope "^7.1.0"
+    eslint-utils "^3.0.0"
+    eslint-visitor-keys "^3.1.0"
+    espree "^9.3.0"
+    esquery "^1.4.0"
+    esutils "^2.0.2"
+    fast-deep-equal "^3.1.3"
+    file-entry-cache "^6.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob-parent "^6.0.1"
+    globals "^13.6.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    is-glob "^4.0.0"
+    js-yaml "^4.1.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.4.1"
+    lodash.merge "^4.6.2"
+    minimatch "^3.0.4"
+    natural-compare "^1.4.0"
+    optionator "^0.9.1"
+    progress "^2.0.0"
+    regexpp "^3.2.0"
+    semver "^7.2.1"
+    strip-ansi "^6.0.1"
+    strip-json-comments "^3.1.0"
+    text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
+
+espree@^9.3.0, espree@^9.3.1, espree@^9.4.0:
   version "9.6.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-9.6.1.tgz#a2a17b8e434690a5432f2f8018ce71d331a48c6f"
   integrity sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==
@@ -1535,6 +1707,11 @@ estree-walker@^3.0.3:
   dependencies:
     "@types/estree" "^1.0.0"
 
+esutils@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
+  integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
 execa@^8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-8.0.1.tgz#51f6a5943b580f963c3ca9c6321796db8cc39b8c"
@@ -1549,6 +1726,11 @@ execa@^8.0.1:
     onetime "^6.0.0"
     signal-exit "^4.1.0"
     strip-final-newline "^3.0.0"
+
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-diff@^1.1.2:
   version "1.3.0"
@@ -1566,6 +1748,16 @@ fast-glob@^3.2.9, fast-glob@^3.3.0, fast-glob@^3.3.2:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
+fast-json-stable-stringify@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
+  integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+
+fast-levenshtein@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+  integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
+
 fastq@^1.6.0:
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.17.1.tgz#2a523f07a4e7b1e81a42b91b8bf2254107753b47"
@@ -1573,12 +1765,33 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
+file-entry-cache@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
+  integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
+  dependencies:
+    flat-cache "^3.0.4"
+
 fill-range@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
   integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
   dependencies:
     to-regex-range "^5.0.1"
+
+flat-cache@^3.0.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.2.0.tgz#2c0c2d5040c99b1632771a9d105725c0115363ee"
+  integrity sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==
+  dependencies:
+    flatted "^3.2.9"
+    keyv "^4.5.3"
+    rimraf "^3.0.2"
+
+flatted@^3.2.9:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
+  integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
 
 foreground-child@^3.1.0:
   version "3.1.1"
@@ -1593,6 +1806,11 @@ fraction.js@^4.3.7:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.3.7.tgz#06ca0085157e42fda7f9e726e79fefc4068840f7"
   integrity sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==
 
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+  integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
 fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -1602,6 +1820,11 @@ function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+  integrity sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -1632,7 +1855,7 @@ glob-parent@^5.1.2, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob-parent@^6.0.2:
+glob-parent@^6.0.1, glob-parent@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
@@ -1650,12 +1873,24 @@ glob@^10.3.10:
     minipass "^7.1.2"
     path-scurry "^1.11.1"
 
+glob@^7.1.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-globals@^13.24.0:
+globals@^13.19.0, globals@^13.24.0, globals@^13.6.0:
   version "13.24.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-13.24.0.tgz#8432a19d78ce0c1e833949c36adb345400bb1171"
   integrity sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==
@@ -1694,6 +1929,11 @@ has-flag@^3.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==
 
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
 hasown@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
@@ -1716,6 +1956,11 @@ human-signals@^5.0.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-5.0.0.tgz#42665a284f9ae0dade3ba41ebc37eb4b852f3a28"
   integrity sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==
 
+ignore@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
+  integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
 ignore@^5.2.0, ignore@^5.2.4, ignore@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.1.tgz#5073e554cd42c5b33b394375f538b8593e34d4ef"
@@ -1725,6 +1970,32 @@ immutable@^4.0.0:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.6.tgz#6a05f7858213238e587fb83586ffa3b4b27f0447"
   integrity sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ==
+
+import-fresh@^3.0.0, import-fresh@^3.2.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.1.tgz#9cecb56503c0ada1f2741dbbd6546e4b13b57ccf"
+  integrity sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
+
+imurmurhash@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+  integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
+
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
+  integrity sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@2:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
+  integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
 is-binary-path@~2.1.0:
   version "2.1.0"
@@ -1750,7 +2021,7 @@ is-fullwidth-code-point@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
-is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -1796,15 +2067,52 @@ js-tokens@^9.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-9.0.0.tgz#0f893996d6f3ed46df7f0a3b12a03f5fd84223c1"
   integrity sha512-WriZw1luRMlmV3LGJaR6QOJjWwgLUTf89OwT2lUOyjX2dJGBwgmIkbcz+7WFZjrZM635JOIR517++e/67CP9dQ==
 
+js-yaml@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
+
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
+json-buffer@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
+  integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
+
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
+
 json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
+
+keyv@^4.5.3:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
+  integrity sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
+  dependencies:
+    json-buffer "3.0.1"
+
+levn@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
+  integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
+  dependencies:
+    prelude-ls "^1.2.1"
+    type-check "~0.4.0"
 
 lilconfig@^2.1.0:
   version "2.1.0"
@@ -1828,6 +2136,11 @@ local-pkg@^0.5.0:
   dependencies:
     mlly "^1.4.2"
     pkg-types "^1.0.3"
+
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lodash@^4.17.21:
   version "4.17.21"
@@ -1883,6 +2196,13 @@ mimic-fn@^4.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-4.0.0.tgz#60a90550d5cb0b239cca65d893b1a53b29871ecc"
   integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
 
+minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimatch@^9.0.0, minimatch@^9.0.3, minimatch@^9.0.4:
   version "9.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.4.tgz#8e49c731d1749cbec05050ee5145147b32496a51"
@@ -1894,6 +2214,11 @@ minimatch@^9.0.0, minimatch@^9.0.3, minimatch@^9.0.4:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
   integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
+
+mitt@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.1.tgz#ea36cf0cc30403601ae074c8f77b7092cdab36d1"
+  integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
 
 mlly@^1.4.2, mlly@^1.7.0:
   version "1.7.0"
@@ -1909,6 +2234,11 @@ ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+ms@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
 muggle-string@^0.4.0:
   version "0.4.1"
@@ -1973,12 +2303,31 @@ object-hash@^3.0.0:
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-3.0.0.tgz#73f97f753e7baffc0e2cc9d6e079079744ac82e9"
   integrity sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==
 
+once@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
+  dependencies:
+    wrappy "1"
+
 onetime@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-6.0.0.tgz#7c24c18ed1fd2e9bca4bd26806a33613c77d34b4"
   integrity sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==
   dependencies:
     mimic-fn "^4.0.0"
+
+optionator@^0.9.1:
+  version "0.9.4"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.4.tgz#7ea1c1a5d91d764fb282139c88fe11e182a3a734"
+  integrity sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==
+  dependencies:
+    deep-is "^0.1.3"
+    fast-levenshtein "^2.0.6"
+    levn "^0.4.1"
+    prelude-ls "^1.2.1"
+    type-check "^0.4.0"
+    word-wrap "^1.2.5"
 
 p-limit@^5.0.0:
   version "5.0.0"
@@ -1987,10 +2336,22 @@ p-limit@^5.0.0:
   dependencies:
     yocto-queue "^1.0.0"
 
+parent-module@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
+  integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
+  dependencies:
+    callsites "^3.0.0"
+
 path-browserify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
   integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
+
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
+  integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
 path-key@^3.1.0:
   version "3.1.1"
@@ -2138,6 +2499,11 @@ postcss@^8.4.23, postcss@^8.4.38:
     picocolors "^1.0.0"
     source-map-js "^1.2.0"
 
+prelude-ls@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
+  integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
 prettier-linter-helpers@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
@@ -2158,6 +2524,16 @@ pretty-format@^29.7.0:
     "@jest/schemas" "^29.6.3"
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
+
+progress@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
+punycode@^2.1.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
+  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
 quasar@~2.16.4:
   version "2.16.4"
@@ -2193,6 +2569,16 @@ regexp-tree@~0.1.1:
   resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.1.27.tgz#2198f0ef54518ffa743fe74d983b56ffd631b6cd"
   integrity sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==
 
+regexpp@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
+  integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
+
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+  integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
 resolve-pkg-maps@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz#616b3dc2c57056b5588c31cdf4b3d64db133720f"
@@ -2211,6 +2597,13 @@ reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
 
 rollup@^4.13.0:
   version "4.18.0"
@@ -2269,6 +2662,11 @@ semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^7.2.1:
+  version "7.7.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.3.tgz#4b5f4143d007633a8dc671cd0a6ef9147b8bb946"
+  integrity sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==
 
 semver@^7.3.6, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0:
   version "7.6.2"
@@ -2370,6 +2768,11 @@ strip-final-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-3.0.0.tgz#52894c313fbff318835280aed60ff71ebf12b8fd"
   integrity sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==
 
+strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
 strip-literal@^2.0.0, strip-literal@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/strip-literal/-/strip-literal-2.1.0.tgz#6d82ade5e2e74f5c7e8739b6c84692bd65f0bd2a"
@@ -2396,6 +2799,13 @@ supports-color@^5.3.0:
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
+
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
 
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
@@ -2447,6 +2857,11 @@ tapable@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
+
+text-table@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+  integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
 
 thenify-all@^1.0.0:
   version "1.6.0"
@@ -2503,6 +2918,13 @@ tslib@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
+type-check@^0.4.0, type-check@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
+  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
+  dependencies:
+    prelude-ls "^1.2.1"
 
 type-detect@^4.0.0, type-detect@^4.0.8:
   version "4.0.8"
@@ -2580,10 +3002,22 @@ update-browserslist-db@^1.0.13:
     escalade "^3.1.2"
     picocolors "^1.0.1"
 
+uri-js@^4.2.2:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
+  integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
+  dependencies:
+    punycode "^2.1.0"
+
 util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
+v8-compile-cache@^2.0.3:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.4.0.tgz#cdada8bec61e15865f05d097c5f4fd30e94dc128"
+  integrity sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==
 
 vite-node@1.6.0:
   version "1.6.0"
@@ -2711,6 +3145,11 @@ why-is-node-running@^2.2.2:
     siginfo "^2.0.0"
     stackback "0.0.2"
 
+word-wrap@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
+  integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
+
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
@@ -2728,6 +3167,11 @@ wrap-ansi@^8.1.0:
     ansi-styles "^6.1.0"
     string-width "^5.0.1"
     strip-ansi "^7.0.1"
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+  integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
 xml-name-validator@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1246,9 +1246,9 @@ camelcase@^6.3.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001599:
-  version "1.0.30001621"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001621.tgz#4adcb443c8b9c8303e04498318f987616b8fea2e"
-  integrity sha512-+NLXZiviFFKX0fk8Piwv3PfLPGtRqJeq2TiNoUff/qB5KJgwecJTvCXDpmlyP/eCI/GUEmp/h/y5j0yckiiZrA==
+  version "1.0.30001793"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz"
+  integrity sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==
 
 chai@^4.3.10:
   version "4.4.1"


### PR DESCRIPTION
## Summary

- Replaces the flat button grid in the **basic** keycode tab with a visual full-size ANSI keyboard layout (function row, main block, edit cluster, navigation arrows, numpad)
- Keys outside the 104-key ANSI layout appear below in labeled groups matching QMK docs categories: Extended F-Keys, Non-US, Locking Keys, Numpad Extras, Commands, International
- Unifies key button size across the keyboard layout, overflow groups, and all other keycode tabs (4.5rem x 4.5rem for 1u keys)
- Removes the expand-on-hover zoom effect from keyboard layout keys
- Adds "Device is locked" tooltip to keyboard layout keys (was missing)
- Fixes tooltip text wrapping near window edges with `white-space: nowrap`