### PR TITLE
Device Info display and minor UI tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,11 @@ dist-ssr
 .yarn
 target
 
+# Tauri generates a per-OS ACL schema under gen/schemas at build time. Upstream
+# tracks the linux/desktop variants; macOS builds additionally emit this one, so
+# keep it out instead of committing a per-developer artifact.
+src-tauri/gen/schemas/macOS-schema.json
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/src-tauri/src/xap/device.rs
+++ b/src-tauri/src/xap/device.rs
@@ -119,6 +119,7 @@ pub struct XapDeviceState {
     #[serde(skip)]
     pub keymap: Keymap,
     pub config: Config,
+    pub config_json: String,
     pub secure_status: XapSecureStatus,
 }
 
@@ -154,6 +155,7 @@ impl XapDevice {
                 layouts: HashMap::new(),
                 matrix_size: Point2D { x: 0, y: 0 },
             },
+            config_json: String::new(),
             secure_status: XapSecureStatus::Locked,
         };
 
@@ -494,7 +496,9 @@ impl XapDevice {
 
         decoder.read_to_string(&mut decompressed)?;
 
-        self.state.config = serde_json::from_str(&decompressed)?;
+        let value: serde_json::Value = serde_json::from_str(&decompressed)?;
+        self.state.config_json = serde_json::to_string_pretty(&value)?;
+        self.state.config = serde_json::from_value(value)?;
 
         Ok(())
     }

--- a/src-tauri/src/xap/device.rs
+++ b/src-tauri/src/xap/device.rs
@@ -342,10 +342,7 @@ impl XapDevice {
             board_ids,
             manufacturer,
             product_name,
-            hardware_id: format!(
-                "{}{}{}{}",
-                hardware_id[0], hardware_id[1], hardware_id[2], hardware_id[3]
-            ),
+            hardware_id: format_hardware_id(hardware_id),
             jump_to_bootloader_enabled: qmk_caps.contains(QmkCapabilitiesFlags::JumpToBootloader),
             eeprom_reset_enabled: qmk_caps.contains(QmkCapabilitiesFlags::ReinitializeEeprom),
         };
@@ -592,5 +589,26 @@ impl XapDevice {
 
     pub fn secure_status(&self) -> &XapSecureStatus {
         &self.state.secure_status
+    }
+}
+
+fn format_hardware_id(hardware_id: [u32; 4]) -> String {
+    hardware_id
+        .iter()
+        .map(|word| format!("0x{word:08X}"))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn hardware_id_uses_four_hex_words() {
+        assert_eq!(
+            format_hardware_id([0x00000001, 0x0000000A, 0x000000FF, 0x12345678]),
+            "0x00000001 0x0000000A 0x000000FF 0x12345678"
+        );
     }
 }

--- a/src/generated/xap.ts
+++ b/src/generated/xap.ts
@@ -622,6 +622,7 @@ export type XapDeviceState = {
     id: string
     info: XapDeviceInfo | null
     config: Config
+    config_json: string
     secure_status: XapSecureStatus
 }
 export type XapEnabledSubsystemCapabilitiesFlags = number

--- a/src/layouts/baseContainer.vue
+++ b/src/layouts/baseContainer.vue
@@ -1,11 +1,18 @@
 <script setup lang="ts">
     import { storeToRefs } from 'pinia'
+    import { computed } from 'vue'
+    import { useRoute } from 'vue-router'
     import { useXapDeviceStore } from '@/utils/deviceStore'
     import { XapDeviceState } from '@generated/xap'
     import { commands } from '@/utils/commands'
 
     const store = useXapDeviceStore()
     const { device, devices } = storeToRefs(store)
+
+    const route = useRoute()
+    const showSecureButton = computed(
+        () => device.value != null && route.meta.showSecureButton === true,
+    )
 </script>
 
 <template>
@@ -54,7 +61,7 @@
         <q-page-container>
             <router-view v-if="device != null" />
         </q-page-container>
-        <q-page-sticky position="bottom-right" :offset="[24, 24]">
+        <q-page-sticky v-if="showSecureButton" position="bottom-right" :offset="[24, 24]">
             <q-btn
                 fab
                 :loading="device?.secure_status == 'Unlocking'"

--- a/src/pages/DeviceInfoView.vue
+++ b/src/pages/DeviceInfoView.vue
@@ -33,6 +33,12 @@
             await commands.qmkReinitializeEeprom(device.value.id)
         }
     }
+
+    async function copyConfig() {
+        if (device.value?.config_json) {
+            await navigator.clipboard.writeText(device.value.config_json)
+        }
+    }
 </script>
 
 <template>
@@ -89,6 +95,29 @@
                     </div>
                 </template>
             </q-field>
+            <q-expansion-item
+                v-if="device?.config_json"
+                header-class="q-pa-none"
+                expand-separator
+            >
+                <template #header>
+                    <q-item-section>
+                        <h5 class="q-my-none">Firmware Config</h5>
+                    </q-item-section>
+                </template>
+                <q-card flat bordered class="relative-position">
+                    <q-btn
+                        flat
+                        dense
+                        icon="content_copy"
+                        class="absolute-top-right q-ma-sm"
+                        @click.stop="copyConfig"
+                    >
+                        <q-tooltip>Copy</q-tooltip>
+                    </q-btn>
+                    <pre class="config-json">{{ device.config_json }}</pre>
+                </q-card>
+            </q-expansion-item>
             <h5>Secure Actions</h5>
             <q-field filled label="Secure Status" stack-label>
                 <template #control>
@@ -146,3 +175,16 @@
         </div>
     </q-page>
 </template>
+
+<style scoped>
+    .config-json {
+        margin: 0;
+        padding: 12px;
+        max-height: 50vh;
+        overflow: auto;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        font-size: 12px;
+        white-space: pre;
+        tab-size: 2;
+    }
+</style>

--- a/src/pages/DeviceInfoView.vue
+++ b/src/pages/DeviceInfoView.vue
@@ -4,6 +4,7 @@
     import { useXapDeviceStore } from '@/utils/deviceStore'
     import { XapSecureStatus, XapDeviceState } from '@generated/xap'
     import { commands } from '@/utils/commands'
+    import { formatBcdVersion } from '@/utils/format'
     import type { Ref } from 'vue'
 
     const store = useXapDeviceStore()
@@ -65,14 +66,14 @@
             <q-field filled label="XAP Version" stack-label>
                 <template #control>
                     <div class="self-center full-width no-outline" tabindex="0">
-                        {{ device?.info?.xap.version }}
+                        {{ formatBcdVersion(device?.info?.xap.version) }}
                     </div>
                 </template>
             </q-field>
             <q-field filled label="QMK Version" stack-label>
                 <template #control>
                     <div class="self-center full-width no-outline" tabindex="0">
-                        {{ device?.info?.qmk.version }}
+                        {{ formatBcdVersion(device?.info?.qmk.version) }}
                     </div>
                 </template>
             </q-field>

--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatBcdVersion } from './format'
+
+describe('formatBcdVersion', () => {
+    it('formats BCD-encoded XAP and QMK versions as dotted versions', () => {
+        expect(formatBcdVersion(0x03020115)).toBe('3.2.115')
+        expect(formatBcdVersion(0x00030000)).toBe('0.3.0')
+        expect(formatBcdVersion(0x00000001)).toBe('0.0.1')
+    })
+
+    it('formats decimal-string versions returned by the backend', () => {
+        expect(formatBcdVersion(String(0x03020115))).toBe('3.2.115')
+    })
+
+    it('falls back to hex for invalid BCD values', () => {
+        expect(formatBcdVersion(0x03020a15)).toBe('0x03020A15')
+    })
+})

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,19 @@
+export function formatBcdVersion(version: number | string | null | undefined): string {
+    if (version == null) {
+        return ''
+    }
+
+    const raw = typeof version === 'string' ? Number(version) : version
+
+    if (!Number.isFinite(raw) || raw < 0) {
+        return String(version)
+    }
+
+    const hex = Math.trunc(raw).toString(16).padStart(8, '0').slice(-8).toUpperCase()
+
+    if (!/^[0-9]{8}$/.test(hex)) {
+        return `0x${hex}`
+    }
+
+    return `${Number(hex.slice(0, 2))}.${Number(hex.slice(2, 4))}.${Number(hex.slice(4, 8))}`
+}

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -1,5 +1,13 @@
 import { createRouter, createWebHashHistory, RouteRecordRaw } from 'vue-router'
 
+declare module 'vue-router' {
+    interface RouteMeta {
+        // Show the floating secure unlock/lock button on this section. Opt-in:
+        // only set it on sections that perform protected writes to the device.
+        showSecureButton?: boolean
+    }
+}
+
 const routes: RouteRecordRaw[] = [
     {
         name: 'home',
@@ -19,6 +27,7 @@ const routes: RouteRecordRaw[] = [
             {
                 path: 'keymap',
                 component: () => import('@/pages/KeymapView.vue'),
+                meta: { showSecureButton: true },
             },
         ],
     },


### PR DESCRIPTION
A few small Device Info / UI improvements:

- Format the hardware ID as hex words and the XAP/QMK versions as dotted BCD in Device Info.
- Show the floating secure unlock button only on sections that opt in via a `showSecureButton` route meta — currently just Keymap; Info has its own unlock control, so the floating one is no longer shown there.
- Show the full firmware config JSON in a collapsible Info section. The blob is already fetched over XAP; previously everything except `layouts`/`matrix_size` was discarded.
- Gitignore the macOS-generated Tauri ACL schema (`gen/schemas/macOS-schema.json`), which the build regenerates per developer.

Display-only; no protocol changes. `cargo test` and `vitest` green.
