### PR TITLE
app: add broadcast message console

### DIFF
--- a/src-tauri/src/rpc/events.rs
+++ b/src-tauri/src/rpc/events.rs
@@ -4,6 +4,12 @@ use tauri_specta::Event;
 use uuid::Uuid;
 use xap_specs::XapSecureStatus;
 
+#[derive(Clone, Copy, Serialize, Type)]
+pub enum RawBroadcastType {
+    Keyboard,
+    User,
+}
+
 #[derive(Clone, Serialize, Type, Event)]
 #[serde(tag = "kind", content = "data")]
 pub enum XapEvent {
@@ -14,6 +20,11 @@ pub enum XapEvent {
     SecureStatusChanged {
         id: Uuid,
         secure_status: XapSecureStatus,
+    },
+    RawBroadcastReceived {
+        id: Uuid,
+        broadcast_type: RawBroadcastType,
+        payload: Vec<u8>,
     },
     NewDevice {
         id: Uuid,

--- a/src-tauri/src/xap/client.rs
+++ b/src-tauri/src/xap/client.rs
@@ -2,21 +2,46 @@ use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
 use anyhow::{anyhow, Result};
 use hidapi::{DeviceInfo, HidApi};
-use log::error;
 use uuid::Uuid;
 
 use xap_specs::{
-    broadcast::{BroadcastType, LogBroadcast},
+    broadcast::{BroadcastRaw, BroadcastType, LogBroadcast},
     constants::XapConstants,
     request::XapRequest,
+    XapSecureStatus,
 };
 
+use crate::rpc::events::RawBroadcastType;
 use crate::XapEvent;
 
 use super::device::XapDevice;
 
 const XAP_USAGE_PAGE: u16 = 0xFF51;
 const XAP_USAGE: u16 = 0x0058;
+
+fn broadcast_event(
+    id: Uuid,
+    secure_status: XapSecureStatus,
+    broadcast: BroadcastRaw,
+) -> Result<XapEvent> {
+    match broadcast.broadcast_type() {
+        BroadcastType::Log => {
+            let log: LogBroadcast = broadcast.into_xap_broadcast()?;
+            Ok(XapEvent::LogReceived { id, log: log.0 })
+        }
+        BroadcastType::SecureStatus => Ok(XapEvent::SecureStatusChanged { id, secure_status }),
+        BroadcastType::Keyboard => Ok(XapEvent::RawBroadcastReceived {
+            id,
+            broadcast_type: RawBroadcastType::Keyboard,
+            payload: broadcast.payload().to_vec(),
+        }),
+        BroadcastType::User => Ok(XapEvent::RawBroadcastReceived {
+            id,
+            broadcast_type: RawBroadcastType::User,
+            payload: broadcast.payload().to_vec(),
+        }),
+    }
+}
 
 pub(crate) struct XapClient {
     hid: HidApi,
@@ -48,23 +73,11 @@ impl XapClient {
             device.poll()?;
 
             while let Some(broadcast) = device.broadcast_queue.pop_front() {
-                match broadcast.broadcast_type() {
-                    BroadcastType::Log => {
-                        let log: LogBroadcast = broadcast.into_xap_broadcast()?;
-                        events.push(XapEvent::LogReceived {
-                            id: device.id(),
-                            log: log.0,
-                        });
-                    }
-                    BroadcastType::SecureStatus => {
-                        events.push(XapEvent::SecureStatusChanged {
-                            id: device.id(),
-                            secure_status: *device.secure_status(),
-                        });
-                    }
-                    BroadcastType::Keyboard => error!("keyboard broadcasts are not implemented!"),
-                    BroadcastType::User => error!("user broadcasts are not implemented!"),
-                }
+                events.push(broadcast_event(
+                    device.id(),
+                    *device.secure_status(),
+                    broadcast,
+                )?);
             }
         }
 
@@ -148,5 +161,58 @@ impl XapClient {
 
     pub fn get_devices(&self) -> Vec<&XapDevice> {
         self.devices.values().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_user_payload_to_raw_broadcast_event() {
+        let id = Uuid::new_v4();
+        let report = [
+            0xFF,
+            0xFF,
+            BroadcastType::User as u8,
+            0x03,
+            0x01,
+            0x2A,
+            0xFF,
+        ];
+        let broadcast = BroadcastRaw::from_raw_report(&report).expect("failed to read broadcast");
+
+        let event =
+            broadcast_event(id, XapSecureStatus::Locked, broadcast).expect("failed to map event");
+
+        match event {
+            XapEvent::RawBroadcastReceived {
+                id: event_id,
+                broadcast_type: RawBroadcastType::User,
+                payload,
+            } => {
+                assert_eq!(event_id, id);
+                assert_eq!(payload, vec![0x01, 0x2A, 0xFF]);
+            }
+            _ => panic!("expected raw user broadcast event"),
+        }
+    }
+
+    #[test]
+    fn maps_log_payload_to_decoded_log_event() {
+        let id = Uuid::new_v4();
+        let report = [0xFF, 0xFF, BroadcastType::Log as u8, 0x02, b'o', b'k'];
+        let broadcast = BroadcastRaw::from_raw_report(&report).expect("failed to read broadcast");
+
+        let event =
+            broadcast_event(id, XapSecureStatus::Locked, broadcast).expect("failed to map event");
+
+        match event {
+            XapEvent::LogReceived { id: event_id, log } => {
+                assert_eq!(event_id, id);
+                assert_eq!(log, "ok");
+            }
+            _ => panic!("expected decoded log event"),
+        }
     }
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,6 +4,7 @@
     import { Notify, Loading } from 'quasar'
 
     import { addListener, clearListener } from '@/utils/events'
+    import { useBroadcastStore } from '@/utils/broadcastStore'
     import { useXapDeviceStore } from '@/utils/deviceStore'
     import router from '@/utils/routes'
     import { eventBus } from '@/utils/eventbus'
@@ -11,10 +12,12 @@
     import { commands } from '@generated/xap'
 
     const store = useXapDeviceStore()
+    const broadcastStore = useBroadcastStore()
     const { device, devices } = storeToRefs(store)
 
     function addDevice(device: XapDeviceState) {
         const { id } = device
+        broadcastStore.rememberDevice(device)
         console.log('new device with id ' + id + Date.now())
         if (store.addDevice(device)) {
             Notify.create({
@@ -64,6 +67,16 @@
                     const { id, secure_status } = event.data
                     console.log('secure status ' + secure_status + ' for device ' + id)
                     store.updateSecureStatus(id, secure_status)
+                    break
+                }
+                case 'LogReceived': {
+                    const { id, log } = event.data
+                    broadcastStore.appendLog(id, log)
+                    break
+                }
+                case 'RawBroadcastReceived': {
+                    const { id, broadcast_type, payload } = event.data
+                    broadcastStore.appendRaw(id, broadcast_type, payload)
                     break
                 }
             }

--- a/src/generated/xap.ts
+++ b/src/generated/xap.ts
@@ -562,6 +562,7 @@ export type QmkJumpToBootloaderResponse = number
 export type QmkProductNameResponse = UTF8String
 export type QmkReinitializeEepromResponse = number
 export type QmkVersionResponse = number
+export type RawBroadcastType = 'Keyboard' | 'User'
 export type RemapInfo = {
     layer_count: number | null
     set_keycode_enabled: boolean
@@ -629,6 +630,10 @@ export type XapEnabledSubsystemCapabilitiesFlags = number
 export type XapEvent =
     | { kind: 'LogReceived'; data: { id: string; log: string } }
     | { kind: 'SecureStatusChanged'; data: { id: string; secure_status: XapSecureStatus } }
+    | {
+          kind: 'RawBroadcastReceived'
+          data: { id: string; broadcast_type: RawBroadcastType; payload: number[] }
+      }
     | { kind: 'NewDevice'; data: { id: string } }
     | { kind: 'RemovedDevice'; data: { id: string } }
 export type XapInfo = { version: number }

--- a/src/layouts/baseContainer.vue
+++ b/src/layouts/baseContainer.vue
@@ -38,6 +38,12 @@
                         to="/rgb"
                         exact
                     />
+                    <q-route-tab
+                        label="Broadcast"
+                        :disable="device == null"
+                        to="/broadcast"
+                        exact
+                    />
                     <q-route-tab label="Info" :disable="device == null" to="/info" exact />
                 </q-tabs>
             </q-toolbar>

--- a/src/pages/BroadcastView.vue
+++ b/src/pages/BroadcastView.vue
@@ -1,0 +1,459 @@
+<script setup lang="ts">
+    import { storeToRefs } from 'pinia'
+    import { computed, nextTick, ref, watch } from 'vue'
+    import type { Ref } from 'vue'
+
+    import { useBroadcastStore } from '@/utils/broadcastStore'
+    import {
+        BROADCAST_HISTORY_LIMIT,
+        BroadcastTypeFilter,
+        filterBroadcastMessages,
+        formatBroadcastDateTime,
+        formatBroadcastTime,
+        formatConnectionId,
+        formatHexRows,
+    } from '@/utils/broadcast'
+
+    const store = useBroadcastStore()
+    const { messages, sourceNames } = storeToRefs(store)
+
+    const query = ref('')
+    const sourceId: Ref<string | null> = ref(null)
+    const typeFilter: Ref<BroadcastTypeFilter> = ref('All')
+    const autoScroll = ref(true)
+    const feedRef: Ref<HTMLElement | null> = ref(null)
+
+    const sourceOptions = computed(() => [
+        { label: 'Source: All devices', value: null },
+        ...Array.from(sourceNames.value.entries())
+            .sort(([, left], [, right]) => left.localeCompare(right))
+            .map(([value, label]) => ({
+                label: `Source: ${label} (${formatConnectionId(value)})`,
+                value,
+            })),
+    ])
+
+    const visibleMessages = computed(() =>
+        filterBroadcastMessages(
+            messages.value,
+            {
+                query: query.value,
+                sourceId: sourceId.value,
+                type: typeFilter.value,
+            },
+            store.sourceName,
+        ),
+    )
+
+    const statusMessage = computed(() => {
+        if (visibleMessages.value.length === messages.value.length) {
+            return `Showing ${visibleMessages.value.length} of up to ${BROADCAST_HISTORY_LIMIT.toLocaleString()} session messages`
+        }
+
+        return `Showing ${visibleMessages.value.length} of ${messages.value.length} captured messages (up to ${BROADCAST_HISTORY_LIMIT.toLocaleString()} retained)`
+    })
+
+    const lastVisibleSequence = computed(
+        () => visibleMessages.value[visibleMessages.value.length - 1]?.sequence,
+    )
+
+    watch(lastVisibleSequence, async () => {
+        if (!autoScroll.value) {
+            return
+        }
+
+        await nextTick()
+        if (feedRef.value) {
+            feedRef.value.scrollTop = feedRef.value.scrollHeight
+        }
+    })
+
+    function badgeLabel(kind: 'Log' | 'Keyboard' | 'User'): string {
+        return kind === 'Log' ? 'LOG' : `${kind.toUpperCase()} / RAW`
+    }
+</script>
+
+<template>
+    <q-page class="broadcast-page-root">
+        <section class="broadcast-page">
+            <header class="broadcast-header">
+                <div class="page-heading">
+                    <h5>Broadcast Messages</h5>
+                    <span class="listening-status">
+                        <span class="listening-dot"></span>
+                        Listening
+                    </span>
+                </div>
+
+                <div class="broadcast-controls">
+                    <q-input
+                        v-model="query"
+                        class="message-filter"
+                        dense
+                        outlined
+                        clearable
+                        placeholder="Filter messages"
+                    >
+                        <template #prepend>
+                            <q-icon name="search" />
+                        </template>
+                    </q-input>
+                    <q-select
+                        v-model="sourceId"
+                        class="source-filter"
+                        dense
+                        outlined
+                        emit-value
+                        map-options
+                        :options="sourceOptions"
+                    />
+                    <q-btn-toggle
+                        v-model="typeFilter"
+                        class="type-filter"
+                        dense
+                        no-caps
+                        unelevated
+                        toggle-color="primary"
+                        text-color="grey-8"
+                        :options="[
+                            { label: 'All', value: 'All' },
+                            { label: 'Log', value: 'Log' },
+                            { label: 'Raw', value: 'Raw' },
+                        ]"
+                    />
+                    <q-btn
+                        class="clear-button"
+                        outline
+                        no-caps
+                        color="grey-7"
+                        label="Clear"
+                        @click="store.clearMessages()"
+                    />
+                </div>
+            </header>
+
+            <q-card flat bordered class="console-panel">
+                <div ref="feedRef" class="message-feed">
+                    <div v-if="visibleMessages.length === 0" class="empty-feed">
+                        <q-icon name="sensors" size="2rem" color="grey-5" />
+                        <div>No broadcast messages captured.</div>
+                        <div class="empty-detail">
+                            Log, keyboard, and user broadcasts will appear here.
+                        </div>
+                    </div>
+
+                    <article
+                        v-for="message in visibleMessages"
+                        :key="message.sequence"
+                        class="message-block"
+                        :class="`message-${message.kind.toLowerCase()}`"
+                    >
+                        <div class="message-meta">
+                            <time
+                                class="message-time"
+                                :title="formatBroadcastDateTime(message.receivedAt)"
+                            >
+                                {{ formatBroadcastTime(message.receivedAt) }}
+                            </time>
+                            <span class="message-badge">{{ badgeLabel(message.kind) }}</span>
+                            <span class="source-name">{{
+                                store.sourceName(message.deviceId)
+                            }}</span>
+                            <code class="source-id">{{
+                                formatConnectionId(message.deviceId)
+                            }}</code>
+                        </div>
+
+                        <p v-if="message.kind === 'Log'" class="log-payload">{{ message.text }}</p>
+                        <div v-else class="raw-payload">
+                            <div v-if="message.payload.length === 0" class="empty-payload">
+                                Empty payload
+                            </div>
+                            <div
+                                v-for="row in formatHexRows(message.payload)"
+                                :key="row.offset"
+                                class="hex-row"
+                            >
+                                <span class="hex-offset">{{ row.offset }}</span>
+                                <span class="hex-bytes">{{ row.bytes }}</span>
+                                <span class="hex-ascii">{{ row.ascii }}</span>
+                            </div>
+                        </div>
+                    </article>
+                </div>
+
+                <q-separator />
+                <footer class="console-footer">
+                    <span>{{ statusMessage }}</span>
+                    <q-icon class="history-info" name="info_outline" size="1.1rem">
+                        <q-tooltip>
+                            Session history is currently limited to 1,000 messages.
+                        </q-tooltip>
+                    </q-icon>
+                    <q-space />
+                    <q-toggle v-model="autoScroll" dense color="primary" label="Auto-scroll" />
+                </footer>
+            </q-card>
+        </section>
+    </q-page>
+</template>
+
+<style scoped>
+    .broadcast-page-root {
+        display: flex;
+        height: 0;
+        min-width: 0;
+        overflow: hidden;
+        background: #f7f8fb;
+    }
+
+    .broadcast-page {
+        display: flex;
+        flex: 1 1 auto;
+        flex-direction: column;
+        gap: 1rem;
+        min-width: 0;
+        min-height: 0;
+        padding: 1.25rem 1.5rem 1rem;
+    }
+
+    .broadcast-header {
+        display: flex;
+        flex: 0 0 auto;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 1rem;
+    }
+
+    .page-heading {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+    }
+
+    .page-heading h5 {
+        margin: 0;
+        font-weight: 500;
+    }
+
+    .listening-status {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.45rem;
+        padding: 0.2rem 0.65rem;
+        border: 1px solid #bbf7d0;
+        border-radius: 999px;
+        color: #15803d;
+        background: #f0fdf4;
+        font-size: 0.8rem;
+        font-weight: 500;
+    }
+
+    .listening-dot {
+        width: 0.5rem;
+        height: 0.5rem;
+        border-radius: 50%;
+        background: #22c55e;
+    }
+
+    .broadcast-controls {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+        gap: 0.6rem;
+    }
+
+    .message-filter {
+        width: 15rem;
+    }
+
+    .source-filter {
+        width: min(18rem, 100vw);
+    }
+
+    .type-filter {
+        border: 1px solid #d1d5db;
+        border-radius: 0.3rem;
+    }
+
+    .clear-button {
+        min-height: 2.5rem;
+    }
+
+    .console-panel {
+        display: flex;
+        flex: 1 1 auto;
+        flex-direction: column;
+        min-height: 0;
+        min-width: 0;
+        overflow: hidden;
+        border-radius: 0.6rem;
+        background: #fff;
+    }
+
+    .message-feed {
+        display: flex;
+        flex: 1 1 auto;
+        flex-direction: column;
+        gap: 0.75rem;
+        min-height: 18rem;
+        overflow-y: auto;
+        padding: 1rem;
+    }
+
+    .empty-feed {
+        display: flex;
+        flex: 1 1 auto;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 0.4rem;
+        color: #6b7280;
+    }
+
+    .empty-detail {
+        color: #9ca3af;
+        font-size: 0.85rem;
+    }
+
+    .message-block {
+        flex: 0 0 auto;
+        border: 1px solid #e5e7eb;
+        border-left: 3px solid #1976d2;
+        border-radius: 0.45rem;
+        padding: 0.65rem 0.85rem 0.75rem;
+        background: #fff;
+    }
+
+    .message-user {
+        border-left-color: #26a69a;
+    }
+
+    .message-keyboard {
+        border-left-color: #9c27b0;
+    }
+
+    .message-meta {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 0.55rem;
+        color: #6b7280;
+        font-size: 0.8rem;
+    }
+
+    .message-time,
+    .source-id,
+    .raw-payload {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    }
+
+    .message-time {
+        color: #6b7280;
+    }
+
+    .message-badge {
+        padding: 0.12rem 0.45rem;
+        border-radius: 0.3rem;
+        color: #075985;
+        background: #e0f2fe;
+        font-weight: 600;
+        font-size: 0.68rem;
+        letter-spacing: 0.03em;
+    }
+
+    .message-user .message-badge {
+        color: #0f766e;
+        background: #ccfbf1;
+    }
+
+    .message-keyboard .message-badge {
+        color: #7e22ce;
+        background: #f3e8ff;
+    }
+
+    .source-name {
+        padding: 0.15rem 0.5rem;
+        border-radius: 999px;
+        background: #f3f4f6;
+        color: #374151;
+    }
+
+    .source-id {
+        color: #6b7280;
+        font-size: 0.75rem;
+    }
+
+    .log-payload {
+        margin: 0.6rem 0 0;
+        color: #1f2937;
+        font-size: 0.95rem;
+    }
+
+    .raw-payload {
+        overflow-x: auto;
+        margin-top: 0.6rem;
+        padding: 0.55rem 0.7rem;
+        border-radius: 0.35rem;
+        color: #374151;
+        background: #f8fafc;
+        font-size: 0.78rem;
+        line-height: 1.5;
+    }
+
+    .hex-row {
+        display: flex;
+        width: max-content;
+        white-space: pre;
+    }
+
+    .empty-payload {
+        color: #94a3b8;
+        font-style: italic;
+    }
+
+    .hex-offset {
+        flex: 0 0 3.25rem;
+        color: #9ca3af;
+    }
+
+    .hex-bytes {
+        flex: 0 0 auto;
+        color: #334155;
+    }
+
+    .hex-ascii {
+        margin-left: 1.1rem;
+        padding-left: 1rem;
+        border-left: 1px solid #e5e7eb;
+        color: #64748b;
+    }
+
+    .console-footer {
+        display: flex;
+        align-items: center;
+        gap: 0.45rem;
+        padding: 0.55rem 1rem;
+        color: #6b7280;
+        font-size: 0.78rem;
+    }
+
+    .history-info {
+        color: #9ca3af;
+        cursor: help;
+    }
+
+    @media (max-width: 900px) {
+        .broadcast-page {
+            padding: 1rem;
+        }
+
+        .broadcast-controls,
+        .message-filter,
+        .source-filter {
+            width: 100%;
+        }
+    }
+</style>

--- a/src/utils/broadcast.test.ts
+++ b/src/utils/broadcast.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+    appendCappedBroadcastMessage,
+    BroadcastMessage,
+    filterBroadcastMessages,
+    formatBroadcastDateTime,
+    formatBroadcastTime,
+    formatHexRows,
+} from './broadcast'
+
+function logMessage(sequence: number, deviceId: string, text: string): BroadcastMessage {
+    return {
+        sequence,
+        receivedAt: sequence,
+        deviceId,
+        kind: 'Log',
+        text,
+    }
+}
+
+describe('broadcast formatting', () => {
+    it('formats local receive timestamps with millisecond precision', () => {
+        const receivedAt = new Date(2026, 4, 26, 14, 22, 8, 143).getTime()
+
+        expect(formatBroadcastTime(receivedAt)).toBe('14:22:08.143')
+        expect(formatBroadcastDateTime(receivedAt)).toBe('2026-05-26 14:22:08.143')
+    })
+
+    it('renders raw data as offset hex rows with an ASCII gutter', () => {
+        const [row] = formatHexRows([0x01, 0x2a, 0x20, 0x7e, 0xff])
+
+        expect(row).toMatchObject({
+            offset: '0000',
+            ascii: '.* ~.',
+        })
+        expect(row.bytes.trimEnd()).toBe('01 2A 20 7E FF')
+        expect(row.bytes).toHaveLength(48)
+    })
+})
+
+describe('broadcast session behavior', () => {
+    it('keeps only the latest messages when the history cap is reached', () => {
+        let messages: BroadcastMessage[] = []
+
+        messages = appendCappedBroadcastMessage(messages, logMessage(1, 'one', 'first'), 2)
+        messages = appendCappedBroadcastMessage(messages, logMessage(2, 'two', 'second'), 2)
+        messages = appendCappedBroadcastMessage(messages, logMessage(3, 'three', 'third'), 2)
+
+        expect(messages.map((message) => message.sequence)).toEqual([2, 3])
+        expect(appendCappedBroadcastMessage(messages, logMessage(4, 'four', 'fourth'), 1)).toEqual([
+            logMessage(4, 'four', 'fourth'),
+        ])
+    })
+
+    it('filters by source, type, and string or hexadecimal text', () => {
+        const messages: BroadcastMessage[] = [
+            logMessage(1, 'alpha', 'Layer changed to 2'),
+            {
+                sequence: 2,
+                receivedAt: 2,
+                deviceId: 'beta',
+                kind: 'User',
+                payload: [0x01, 0x2a, 0xff],
+            },
+        ]
+        const sourceName = (deviceId: string) =>
+            deviceId === 'alpha' ? 'Mode Designs - SixtyFive' : 'Keebio - Iris'
+
+        expect(
+            filterBroadcastMessages(
+                messages,
+                { query: 'layer', sourceId: null, type: 'Log' },
+                sourceName,
+            ),
+        ).toHaveLength(1)
+        expect(
+            filterBroadcastMessages(
+                messages,
+                { query: '01 2a', sourceId: 'beta', type: 'Raw' },
+                sourceName,
+            ),
+        ).toHaveLength(1)
+        expect(
+            filterBroadcastMessages(
+                messages,
+                { query: 'iris', sourceId: null, type: 'All' },
+                sourceName,
+            ),
+        ).toEqual([messages[1]])
+    })
+})

--- a/src/utils/broadcast.ts
+++ b/src/utils/broadcast.ts
@@ -1,0 +1,134 @@
+import type { RawBroadcastType, XapDeviceState } from '@generated/xap'
+
+export const BROADCAST_HISTORY_LIMIT = 1000
+
+export type BroadcastTypeFilter = 'All' | 'Log' | 'Raw'
+
+export type BroadcastMessage =
+    | {
+          sequence: number
+          receivedAt: number
+          deviceId: string
+          kind: 'Log'
+          text: string
+      }
+    | {
+          sequence: number
+          receivedAt: number
+          deviceId: string
+          kind: RawBroadcastType
+          payload: number[]
+      }
+
+export interface BroadcastFilters {
+    query: string
+    sourceId: string | null
+    type: BroadcastTypeFilter
+}
+
+export interface HexRow {
+    offset: string
+    bytes: string
+    ascii: string
+}
+
+function pad2(value: number): string {
+    return String(value).padStart(2, '0')
+}
+
+function pad3(value: number): string {
+    return String(value).padStart(3, '0')
+}
+
+function formatByte(byte: number): string {
+    return (byte & 0xff).toString(16).padStart(2, '0').toUpperCase()
+}
+
+function printableByte(byte: number): string {
+    const value = byte & 0xff
+    return value >= 0x20 && value <= 0x7e ? String.fromCharCode(value) : '.'
+}
+
+export function formatBroadcastTime(receivedAt: number): string {
+    const date = new Date(receivedAt)
+    return `${pad2(date.getHours())}:${pad2(date.getMinutes())}:${pad2(date.getSeconds())}.${pad3(date.getMilliseconds())}`
+}
+
+export function formatBroadcastDateTime(receivedAt: number): string {
+    const date = new Date(receivedAt)
+    return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())} ${formatBroadcastTime(receivedAt)}`
+}
+
+export function formatConnectionId(id: string): string {
+    return id.length > 12 ? `${id.slice(0, 4)}...${id.slice(-4)}` : id
+}
+
+export function deviceDisplayName(device: XapDeviceState): string {
+    const parts = [device.info?.qmk.manufacturer, device.info?.qmk.product_name].filter(
+        (part): part is string => part != null && part.trim().length > 0,
+    )
+    return parts.join(' - ') || 'Unknown device'
+}
+
+export function formatHexRows(payload: number[]): HexRow[] {
+    const rows: HexRow[] = []
+
+    for (let offset = 0; offset < payload.length; offset += 16) {
+        const chunk = payload.slice(offset, offset + 16)
+        const firstGroup = chunk.slice(0, 8).map(formatByte).join(' ')
+        const secondGroup = chunk.slice(8, 16).map(formatByte).join(' ')
+        rows.push({
+            offset: offset.toString(16).padStart(4, '0').toUpperCase(),
+            bytes: `${firstGroup.padEnd(23, ' ')}  ${secondGroup}`.padEnd(48, ' '),
+            ascii: chunk.map(printableByte).join(''),
+        })
+    }
+
+    return rows
+}
+
+export function appendCappedBroadcastMessage(
+    messages: BroadcastMessage[],
+    message: BroadcastMessage,
+    limit = BROADCAST_HISTORY_LIMIT,
+): BroadcastMessage[] {
+    if (limit <= 0) {
+        return []
+    }
+
+    const retained = limit === 1 ? [] : messages.slice(-(limit - 1))
+    return [...retained, message]
+}
+
+export function filterBroadcastMessages(
+    messages: BroadcastMessage[],
+    filters: BroadcastFilters,
+    sourceName: (deviceId: string) => string,
+): BroadcastMessage[] {
+    const query = filters.query.trim().toLowerCase()
+
+    return messages.filter((message) => {
+        if (filters.sourceId != null && message.deviceId !== filters.sourceId) {
+            return false
+        }
+
+        if (filters.type === 'Log' && message.kind !== 'Log') {
+            return false
+        }
+
+        if (filters.type === 'Raw' && message.kind === 'Log') {
+            return false
+        }
+
+        if (query.length === 0) {
+            return true
+        }
+
+        const payload =
+            message.kind === 'Log'
+                ? message.text
+                : `${message.payload.map(formatByte).join(' ')} ${message.payload.map(printableByte).join('')}`
+        const searchable = `${sourceName(message.deviceId)} ${message.deviceId} ${message.kind} ${payload}`
+        return searchable.toLowerCase().includes(query)
+    })
+}

--- a/src/utils/broadcastStore.ts
+++ b/src/utils/broadcastStore.ts
@@ -1,0 +1,53 @@
+import { defineStore } from 'pinia'
+
+import type { RawBroadcastType, XapDeviceState } from '@generated/xap'
+import {
+    appendCappedBroadcastMessage,
+    BroadcastMessage,
+    deviceDisplayName,
+} from '@/utils/broadcast'
+
+export const useBroadcastStore = defineStore('broadcast-store', {
+    state: () => ({
+        messages: [] as BroadcastMessage[],
+        sourceNames: new Map<string, string>(),
+        nextSequence: 0,
+    }),
+    getters: {
+        sourceName: (state) => (deviceId: string) =>
+            state.sourceNames.get(deviceId) ?? 'Unknown device',
+    },
+    actions: {
+        rememberDevice(device: XapDeviceState) {
+            this.sourceNames.set(device.id, deviceDisplayName(device))
+        },
+        appendLog(deviceId: string, text: string, receivedAt = Date.now()) {
+            this.nextSequence += 1
+            this.messages = appendCappedBroadcastMessage(this.messages, {
+                sequence: this.nextSequence,
+                receivedAt,
+                deviceId,
+                kind: 'Log',
+                text,
+            })
+        },
+        appendRaw(
+            deviceId: string,
+            kind: RawBroadcastType,
+            payload: number[],
+            receivedAt = Date.now(),
+        ) {
+            this.nextSequence += 1
+            this.messages = appendCappedBroadcastMessage(this.messages, {
+                sequence: this.nextSequence,
+                receivedAt,
+                deviceId,
+                kind,
+                payload: [...payload],
+            })
+        },
+        clearMessages() {
+            this.messages = []
+        },
+    },
+})

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -29,6 +29,10 @@ const routes: RouteRecordRaw[] = [
                 component: () => import('@/pages/KeymapView.vue'),
                 meta: { showSecureButton: true },
             },
+            {
+                path: 'broadcast',
+                component: () => import('@/pages/BroadcastView.vue'),
+            },
         ],
     },
 ]

--- a/xap-specs/src/broadcast.rs
+++ b/xap-specs/src/broadcast.rs
@@ -2,7 +2,7 @@ use core::fmt::Debug;
 use std::io::Cursor;
 
 use anyhow::Result;
-use binrw::{binread, BinRead, BinReaderExt, Endian};
+use binrw::{binread, BinRead, Endian};
 use log::trace;
 
 use crate::token::Token;
@@ -34,6 +34,10 @@ impl BroadcastRaw {
         &self.broadcast_type
     }
 
+    pub fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+
     pub fn from_raw_report(report: &[u8]) -> Result<Self> {
         let mut reader = Cursor::new(report);
         let broadcast = Self::read_le(&mut reader)?;
@@ -63,11 +67,7 @@ impl BinRead for LogBroadcast {
         _endian: Endian,
         _args: Self::Args<'_>,
     ) -> binrw::BinResult<Self> {
-        let len: u8 = reader.read_le()?;
-        let mut bytes = Vec::with_capacity(len as usize);
-        reader.read_exact(&mut bytes[..len as usize])?;
-        let mut cursor = Cursor::new(&bytes);
-        Ok(Self(std::io::read_to_string(&mut cursor)?))
+        Ok(Self(std::io::read_to_string(reader)?))
     }
 }
 
@@ -77,3 +77,49 @@ impl XapBroadcast for LogBroadcast {}
 pub struct SecureStatusBroadcast(pub XapSecureStatus);
 
 impl XapBroadcast for SecureStatusBroadcast {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_non_empty_log_broadcast_payload() {
+        let report = [
+            0xFF,
+            0xFF,
+            BroadcastType::Log as u8,
+            0x05,
+            b'h',
+            b'e',
+            b'l',
+            b'l',
+            b'o',
+        ];
+
+        let broadcast = BroadcastRaw::from_raw_report(&report).expect("failed to read broadcast");
+        let log: LogBroadcast = broadcast
+            .into_xap_broadcast()
+            .expect("failed to decode log payload");
+
+        assert_eq!(log.0, "hello");
+    }
+
+    #[test]
+    fn exposes_raw_payload_for_unparsed_broadcasts() {
+        let report = [
+            0xFF,
+            0xFF,
+            BroadcastType::User as u8,
+            0x04,
+            0x01,
+            0x2A,
+            0xFF,
+            0x00,
+        ];
+
+        let broadcast = BroadcastRaw::from_raw_report(&report).expect("failed to read broadcast");
+
+        assert_eq!(broadcast.broadcast_type(), &BroadcastType::User);
+        assert_eq!(broadcast.payload(), &[0x01, 0x2A, 0xFF, 0x00]);
+    }
+}


### PR DESCRIPTION
Adds a Broadcast console page that captures XAP broadcast messages per device and renders them with text and raw hex payloads.

- Backend: surface keyboard/user broadcasts as a `RawBroadcastReceived` event carrying the raw payload, and fix log-broadcast payload decoding.
- Frontend: a Broadcast tab (placed before Info) with capped, per-device message history.

Tests: `cargo test` (broadcast decode + event mapping), `vitest` (formatting).

Screenshot
<img width="1346" height="1328" alt="Screenshot 2026-05-26 at 7 39 22 PM" src="https://github.com/user-attachments/assets/5be38800-c6bf-4e0e-8ce7-6c3cc9d4957f" />
